### PR TITLE
Feature:ログイン・登録後にリロード不要でログイン状態を維持

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "@tailwindcss/vite": "^4.1.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jotai": "^2.15.0",
         "lucide-react": "^0.545.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -45,7 +46,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -58,7 +59,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.28.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -66,7 +67,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.28.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -95,7 +96,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -103,7 +104,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
@@ -118,7 +119,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -133,7 +134,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -141,7 +142,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -149,7 +150,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -161,7 +162,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -185,7 +186,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -193,7 +194,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.27.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -201,7 +202,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -209,7 +210,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -221,7 +222,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.28.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.4"
@@ -263,7 +264,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -276,7 +277,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.28.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -293,7 +294,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.28.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2111,7 +2112,7 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.12",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -2139,7 +2140,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.26.3",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2185,7 +2186,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001748",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2270,7 +2271,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2302,7 +2303,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2338,7 +2339,7 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.232",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2395,7 +2396,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2753,7 +2754,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2889,14 +2890,43 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jotai": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.15.0.tgz",
+      "integrity": "sha512-nbp/6jN2Ftxgw0VwoVnOg0m5qYM1rVcfvij+MZx99Z5IK13eGve9FJoCwGv+17JvVthTjhSmNtT5e1coJnr6aw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -2922,7 +2952,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3186,7 +3216,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -3264,7 +3294,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3290,7 +3320,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.23",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/normalize-range": {
@@ -3881,7 +3911,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4119,7 +4149,7 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.1.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jotai": "^2.15.0",
     "lucide-react": "^0.545.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/client/src/atoms/authAtoms.ts
+++ b/client/src/atoms/authAtoms.ts
@@ -1,0 +1,4 @@
+import { atom } from "jotai";
+import type { User } from "@/types/authTypes";
+
+export const userAtom = atom<User | null>(null);

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -17,18 +17,11 @@ import {
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu";
+import type { User as UserType } from "@/types/authTypes";
 
-interface User {
-  id: number;
-  name: string;
-  email: string;
-  email_verified_at: string | null;
-  created_at: string;
-  updated_at: string;
-}
 
 function Header() {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<UserType | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
 

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu";
 import type { User as UserType } from "@/types/authTypes";
+import { fetchUser, logout } from "@/services/authService";
 
 
 function Header() {
@@ -25,52 +26,16 @@ function Header() {
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
 
-  const fetchUser = async () => {
-    try {
-      setIsLoading(true);
-
-      const response = await fetch("http://localhost:8000/user", {
-        method: "GET",
-        headers: {
-          "Accept": "application/json"
-        },
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        const userData = await response.json();
-        setUser(userData);
-      } else if (response.status === 401) {
-        setUser(null);
-      }
-    } catch (err) {
-      console.error("User fetch error:", err);
-      setUser(null);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleLogout = async () => {
-    try {
-      await fetch("http://localhost:8000/logout", {
-        method: "POST",
-        headers: {
-          "Accept": "application/json",
-        },
-        credentials: "include",
-      });
-
-      setUser(null);
-      navigate("/login");
-    } catch (err) {
-      console.error("Logout error:", err);
-    }
-  };
-
   useEffect(() => {
-    fetchUser();
+    fetchUser().then(setUser);
   }, []);
+
+  const handleLogoutClick = async () => {
+    await logout();
+    setUser(null);
+    navigate("/login");
+  };
+
   return (
     <>
       <div className="border-b">
@@ -125,7 +90,7 @@ function Header() {
                           <div className="text-gray-600">{user.email}</div>
                         </div>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={handleLogout}>
+                        <DropdownMenuItem onClick={handleLogoutClick}>
                           ログアウト
                         </DropdownMenuItem>
                       </>

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -18,12 +18,13 @@ import {
 import { Button } from "../ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu";
 import type { User as UserType } from "@/types/authTypes";
+import { useAtom } from "jotai";
+import { userAtom } from "@/atoms/authAtoms";
 import { fetchUser, logout } from "@/services/authService";
 
 
 function Header() {
-  const [user, setUser] = useState<UserType | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [user, setUser] = useAtom(userAtom);
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const getCsrfToken = () => {
+  const cookies = document.cookie.split(';');
+  const xsrfCookie = cookies.find(cookie => cookie.trim().startsWith('XSRF-TOKEN='));
+  if (xsrfCookie) {
+    return decodeURIComponent(xsrfCookie.split('=')[1]);
+  }
+  return null;
+};

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -4,6 +4,8 @@ import Heading from "@/components/Heading";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getCsrfToken } from "@/lib/utils";
+import { login } from "@/services/authService";
 
 const Login = () => {
   const [email, setEmail] = useState("");
@@ -12,59 +14,12 @@ const Login = () => {
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
-  const getCsrfToken = () => {
-    const cookies = document.cookie.split(';');
-    const xsrfCookie = cookies.find(cookie => cookie.trim().startsWith('XSRF-TOKEN='));
-    if (xsrfCookie) {
-      return decodeURIComponent(xsrfCookie.split('=')[1]);
-    }
-    return null;
-  };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
-    setError("");
-
-    try {
-      // CSRFトークンを取得
-      await fetch("http://localhost:8000/sanctum/csrf-cookie", {
-        method: "GET",
-        credentials: "include",
-      });
-
-      // XSRF-TOKENクッキーからCSRFトークンを取得
-      const csrfToken = getCsrfToken();
-
-      // ログインリクエスト
-      const response = await fetch("http://localhost:8000/login", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Accept": "application/json",
-          ...(csrfToken && { "X-XSRF-TOKEN": csrfToken }),
-        },
-        credentials: "include",
-        body: JSON.stringify({
-          email,
-          password,
-        }),
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        console.log("Login successful:", data);
-        navigate("/"); // ログイン成功後、トップページにリダイレクト
-      } else {
-        const errorData = await response.json();
-        setError(errorData.message || "ログインに失敗しました");
-      }
-    } catch (err) {
-      setError("ネットワークエラーが発生しました");
-      console.error("Login error:", err);
-    } finally {
-      setIsLoading(false);
-    }
+    const csrfToken = getCsrfToken();
+    const response = await login(email, password, csrfToken!);
+    if (response.ok) navigate("/");
+    else setError("ログイン失敗");
   };
 
   return (

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getCsrfToken } from "@/lib/utils";
+import { useAtom } from "jotai";
+import { userAtom } from "@/atoms/authAtoms";
 import { login } from "@/services/authService";
 
 const Login = () => {
@@ -14,12 +16,19 @@ const Login = () => {
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
+  const [, setUser] = useAtom(userAtom);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const csrfToken = getCsrfToken();
     const response = await login(email, password, csrfToken!);
-    if (response.ok) navigate("/");
-    else setError("ログイン失敗");
+    if (response.ok) {
+      const data = await response.json();
+      setUser(data.user);
+      navigate("/");
+    } else {
+      setError("ログイン失敗");
+    }
   };
 
   return (

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -4,6 +4,8 @@ import Heading from "@/components/Heading";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getCsrfToken } from "@/lib/utils";
+import { useAtom } from "jotai";
+import { userAtom } from "@/atoms/authAtoms";
 import { signup } from "@/services/authService";
 
 const Signup = () => {
@@ -14,6 +16,8 @@ const Signup = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
+
+  const [, setUser] = useAtom(userAtom);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -40,6 +44,8 @@ const Signup = () => {
       const response = await signup(name, email, password, passwordConfirmation, csrfToken);
 
       if (response.ok) {
+        const data = await response.json();
+        setUser(data.user);
         navigate("/");
       } else {
         const errorData = await response.json();

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import Heading from "@/components/Heading";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getCsrfToken } from "@/lib/utils";
+import { signup } from "@/services/authService";
 
 const Signup = () => {
   const [name, setName] = useState("");
@@ -13,21 +15,11 @@ const Signup = () => {
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
-  const getCsrfToken = () => {
-    const cookies = document.cookie.split(';');
-    const xsrfCookie = cookies.find(cookie => cookie.trim().startsWith('XSRF-TOKEN='));
-    if (xsrfCookie) {
-      return decodeURIComponent(xsrfCookie.split('=')[1]);
-    }
-    return null;
-  };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
     setError("");
 
-    // バリデーション
     if (password !== passwordConfirmation) {
       setError("パスワードが一致しません");
       setIsLoading(false);
@@ -41,40 +33,17 @@ const Signup = () => {
     }
 
     try {
-      // まずCSRFトークンを取得
-      await fetch("http://localhost:8000/sanctum/csrf-cookie", {
-        method: "GET",
-        credentials: "include",
-      });
-
-      // XSRF-TOKENクッキーからトークンを取得
+      // CSRFトークン取得
       const csrfToken = getCsrfToken();
 
-      // サインアップリクエストを送信
-      const response = await fetch("http://localhost:8000/register", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Accept": "application/json",
-          ...(csrfToken && { "X-XSRF-TOKEN": csrfToken }),
-        },
-        credentials: "include",
-        body: JSON.stringify({
-          name,
-          email,
-          password,
-          password_confirmation: passwordConfirmation,
-        }),
-      });
+      // サインアップAPI呼び出し
+      const response = await signup(name, email, password, passwordConfirmation, csrfToken);
 
       if (response.ok) {
-        const data = await response.json();
-        console.log("Signup successful:", data);
-        navigate("/"); // サインアップ成功後、トップページにリダイレクト
+        navigate("/");
       } else {
         const errorData = await response.json();
         if (errorData.errors) {
-          // Laravelのバリデーションエラー
           const errorMessages = Object.values(errorData.errors).flat();
           setError(errorMessages.join(", "));
         } else {
@@ -82,8 +51,8 @@ const Signup = () => {
         }
       }
     } catch (err) {
-      setError("ネットワークエラーが発生しました");
       console.error("Signup error:", err);
+      setError("ネットワークエラーが発生しました");
     } finally {
       setIsLoading(false);
     }

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,4 +1,5 @@
 import type { User } from "@/types/authTypes";
+import { getCsrfToken } from "@/lib/utils";
 
 const API_URL = "http://localhost:8000";
 
@@ -64,9 +65,18 @@ export const login = async (email: string, password: string, csrfToken: string) 
 
 // ログアウト
 export const logout = async () => {
-  await fetch(`${API_URL}/logout`, {
+  const csrfToken = getCsrfToken();
+
+  const response = await fetch(`${API_URL}/logout`, {
     method: "POST",
-    headers: { Accept: "application/json" },
+    headers: {
+      "Accept": "application/json",
+      "X-XSRF-TOKEN": csrfToken ?? "",
+    },
     credentials: "include",
   });
+
+  if (!response.ok) {
+    console.error("Logout failed:", response.status);
+  }
 };

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,0 +1,72 @@
+import type { User } from "@/types/authTypes";
+
+const API_URL = "http://localhost:8000";
+
+// ユーザ情報取得
+export const fetchUser = async (): Promise<User | null> => {
+  try {
+    const response = await fetch(`${API_URL}/user`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      credentials: "include",
+    });
+
+    if (response.ok) return await response.json();
+    if (response.status === 401) return null;
+  } catch (err) {
+    console.error("fetchUser error:", err);
+    return null;
+  }
+};
+
+// サインアップ
+export const signup = async (
+  name: string,
+  email: string,
+  password: string,
+  passwordConfirmation: string,
+  csrfToken: string | null
+) => {
+  const response = await fetch(`${API_URL}/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+      ...(csrfToken && { "X-XSRF-TOKEN": csrfToken }),
+    },
+    credentials: "include",
+    body: JSON.stringify({
+      name,
+      email,
+      password,
+      password_confirmation: passwordConfirmation,
+    }),
+  });
+
+  return response;
+};
+
+//　ログイン
+export const login = async (email: string, password: string, csrfToken: string) => {
+  const response = await fetch(`${API_URL}/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+      "X-XSRF-TOKEN": csrfToken,
+    },
+    credentials: "include",
+    body: JSON.stringify({ email, password }),
+  });
+  return response;
+};
+
+
+// ログアウト
+export const logout = async () => {
+  await fetch(`${API_URL}/logout`, {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    credentials: "include",
+  });
+};

--- a/client/src/types/authTypes.ts
+++ b/client/src/types/authTypes.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  email_verified_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/server/laravel/app/Http/Controllers/AuthController.php
+++ b/server/laravel/app/Http/Controllers/AuthController.php
@@ -49,7 +49,17 @@ class AuthController extends Controller
 
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
-            return response()->json(['message' => 'Login successful']);
+
+            $user = Auth::user();
+
+            return response()->json([
+                'message' => 'Login successful',
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                ],
+            ]);
         }
 
         return response()->json([


### PR DESCRIPTION
### 概要
- ヘッダーのユーザー情報（DropdownMenu）の表示を、ページリロードなしで更新できるように変更
- ログイン・登録直後にトップページに遷移してもログイン状態が反映されるように対応

### 変更内容
1. 型定義の整理
   - Header.tsx 内にあった User 型定義を types/authTypes.ts に移動
2. API 接続を authService.ts に集約
3. Jotai を使用してグローバルにユーザー状態を管理
   - userAtom を作成
   - Header.tsx で useAtom を使用し、ユーザー状態を監視
   - Login.tsx / Signup.tsx で atom を更新
4. ログアウト時も Header の状態が正しく更新されるよう修正

### 動作確認
- ログイン後、ページリロード不要で Header の DropdownMenu がログイン状態を表示
- 新規登録後も同様にログイン状態が反映
- ログアウト時に Header が未ログイン状態に切り替わる

### 補足
- authService.ts 内で fetchUser / login / logout の処理を整理
- Laravel 側でログインユーザー情報を返すよう API を修正済み
