### PR TITLE
Feat:ユーザー登録時のメール送信機能の実装と設定

### DIFF
--- a/server/laravel/app/Http/Controllers/AuthController.php
+++ b/server/laravel/app/Http/Controllers/AuthController.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\WelcomeMail;
 
 class AuthController extends Controller
 {
@@ -30,6 +32,9 @@ class AuthController extends Controller
 
         // ユーザーをログイン状態にする
         Auth::login($user);
+
+        // メール送信機能追加
+        Mail::to($user->email)->send(new WelcomeMail($user));
 
         return response()->json([
             'message' => 'User registered successfully',

--- a/server/laravel/app/Http/Controllers/AuthController.php
+++ b/server/laravel/app/Http/Controllers/AuthController.php
@@ -9,10 +9,18 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
-use App\Mail\WelcomeMail;
+use App\Services\MailService;
 
 class AuthController extends Controller
 {
+
+    protected $mailService;
+
+    public function __construct(MailService $mailService)
+    {
+        $this->mailService = $mailService;
+    }
+
     /**
      * Register a new user.
      */
@@ -34,7 +42,7 @@ class AuthController extends Controller
         Auth::login($user);
 
         // メール送信機能追加
-        Mail::to($user->email)->send(new WelcomeMail($user));
+        $this->mailService->sendWelcomeMail($user);
 
         return response()->json([
             'message' => 'User registered successfully',

--- a/server/laravel/app/Mail/WelcomeMail.php
+++ b/server/laravel/app/Mail/WelcomeMail.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use App\Models\User;
+
+class WelcomeMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $user;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(User $user)
+    {
+        //
+        $this->user = $user;
+    }
+
+    public function build()
+    {
+        return $this->subject('Welcome to Service!')
+                    ->view('emails.welcome');
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Welcome Mail',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.welcome',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/server/laravel/app/Mail/WelcomeMail.php
+++ b/server/laravel/app/Mail/WelcomeMail.php
@@ -10,14 +10,14 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\User;
 
-class WelcomeMail extends Mailable
+class WelcomeMail extends Mailable //implements ShouldQueue
 {
     use Queueable, SerializesModels;
 
     public $user;
 
     /**
-     * Create a new message instance.
+     * メッセージのインスタンスを作成
      */
     public function __construct(User $user)
     {
@@ -27,37 +27,7 @@ class WelcomeMail extends Mailable
 
     public function build()
     {
-        return $this->subject('Welcome to Service!')
+        return $this->subject('リカージョン ECサイトへようこそ')
                     ->view('emails.welcome');
-    }
-
-    /**
-     * Get the message envelope.
-     */
-    public function envelope(): Envelope
-    {
-        return new Envelope(
-            subject: 'Welcome Mail',
-        );
-    }
-
-    /**
-     * Get the message content definition.
-     */
-    public function content(): Content
-    {
-        return new Content(
-            view: 'emails.welcome',
-        );
-    }
-
-    /**
-     * Get the attachments for the message.
-     *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
-     */
-    public function attachments(): array
-    {
-        return [];
     }
 }

--- a/server/laravel/app/Services/MailService.php
+++ b/server/laravel/app/Services/MailService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Mail;
+use App\Mail\WelcomeMail;
+use App\Models\User;
+use App\Models\Order;
+
+
+class MailService
+{
+    /**
+     * ユーザー登録時のウェルカムメール　（非同期処理にキューを使用可能）
+     */
+    public function sendWelcomeMail(User $user)
+    {
+        Mail::to($user->email)->send(new WelcomeMail($user));
+    }
+
+    /**
+     * 注文出荷メール（今後実装予定）
+     */
+    // public function sendOrderShippedMail(Order $order)
+    // {
+    //     Mail::to($order->user->email)->send(new OrderShippedMail($order));
+    // }
+
+    /**
+     * 購入完了メール　(今後実装予定）
+     */
+    // public function sendPurchaseMail(Order $order)
+    // {
+    //     Mail::to($order->user->email)->send(new PurchaseMail($order));
+    // }
+}

--- a/server/laravel/resources/views/emails/welcome.blade.php
+++ b/server/laravel/resources/views/emails/welcome.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+    <h2>ようこそ、{{ $user->name }}さん!</h2>
+    <p>ご登録ありがとうございます！</p>
+    <p>こちら登録完了メールです</p>
+</body>
+</html>

--- a/server/laravel/tests/Feature/AuthTest.php
+++ b/server/laravel/tests/Feature/AuthTest.php
@@ -8,6 +8,9 @@ use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\WelcomeMail;
+
 
 class AuthTest extends TestCase
 {
@@ -227,5 +230,32 @@ class AuthTest extends TestCase
                         'name' => 'John Doe',
                         'email' => 'john@example.com',
                     ]);
+    }
+
+    /**
+     * Test mail successfully receive email when register success
+     */
+    public function test_it_sends_welcome_email_on_registration()
+    {
+        Mail::fake();
+
+        $userData = [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ];
+
+        // ユーザー登録APIを呼び出す
+        $response = $this->postJson('/register', $userData);
+
+        $response->assertStatus(201);
+
+        $user = User::where('email', 'test@example.com')->first();
+
+        // WelcomeMail が送信されたか確認
+        Mail::assertSent(WelcomeMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email);
+        });
     }
 }


### PR DESCRIPTION
## 概要: 
- ユーザーが新規登録した際に、Welcomeメールを送信する機能を AuthController のregister()に実装しました。
- Mail クラス作成: WelcomeMail を作成し、ユーザー情報を渡してメールを送信。
- .env 設定: メール送信のために .env に SMTP 設定を追加
- 本番では Gmail や任意の SMTP サーバーを利用可能になります
- 開発環境やテストでは MailTrap を使用して安全にメール送信確認
- テスト: Laravel の Feature Test (AuthTest) で登録時に WelcomeMail が送信されることを確認
- Mail::fake() を使用して送信テストを安全に実行
- Mail 到着確認: MailTrap を使用してメールが正しく送信されるかを確認可能

1.MailTrapでアカウントを作成
2. Email Sandboxを選択
3. HomeにあるSandboxを選択
4. SMTPを選択
5. code sampleからPHP: Laravel 7.x and 8.xを指定
6. .envを書き換える

<pre>.env (例)
MAIL_MAILER=smtp 
MAIL_HOST=sandbox.smtp.mailtrap.io 
MAIL_PORT=2525 
MAIL_USERNAME=xxxxx 
MAIL_PASSWORD=xxxxx 
MAIL_ENCRYPTION=tls 
MAIL_FROM_ADDRESS=example@example.com 
MAIL_FROM_NAME=Laravel
</pre>

今後の拡張性: 支払い通知や配送通知など、他のメール送信機能も同様の仕組みで簡単に追加可能です