### PR TITLE
Feature/category page カテゴリ管理画面の実装

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,35 +1,42 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import Layout from "@/components/Layout/Layout";
-import Top from "@/pages/Top";
-import Delivery from "@/pages/Delivery";
-import ProductList from "@/pages/ProductList";
-import Login from "./pages/Login";
-import Signup from "./pages/Signup";
-import AdminLayout from "./components/Layout/admin/AdminLayout";
-import AdminProductList from "@/pages/admin/AdminProductList";
-import AdminProductCreate from "@/pages/admin/AdminProductCreate";
-import AdminProductEdit from "@/pages/admin/AdminProductEdit";
-import ProductDetail from "./pages/ProductDetail";
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Layout from '@/components/Layout/Layout';
+import Top from '@/pages/Top';
+import Delivery from '@/pages/Delivery';
+import ProductList from '@/pages/ProductList';
+import Login from './pages/Login';
+import Signup from './pages/Signup';
+import AdminLayout from './components/Layout/admin/AdminLayout';
+import AdminProductList from '@/pages/admin/AdminProductList';
+import AdminProductCreate from '@/pages/admin/AdminProductCreate';
+import AdminProductEdit from '@/pages/admin/AdminProductEdit';
+import ProductDetail from './pages/ProductDetail';
+import AdminCategoryList from '@/pages/admin/AdminCategoryList';
+import AdminCategoryCreate from '@/pages/admin/AdminCategoryCreate';
+import AdminCategoryEdit from '@/pages/admin/AdminCategoryEdit';
 
 function App() {
   return (
     <Router>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route path="/" element={<Top />} />
-            <Route path="/delivery" element={<Delivery />} />
-            <Route path="/products" element={<ProductList/>} />
-            <Route path="/products/:id" element={<ProductDetail/>} /> 
-            <Route path="/login" element={<Login/>} />
-            <Route path="/signup" element={<Signup/>} />
-          </Route>
-          <Route path="admin" element={<AdminLayout />}>
-            <Route path="products" element={<AdminProductList />} />
-            <Route path="products/create" element={<AdminProductCreate />} />
-            <Route path="products/:id" element={<AdminProductEdit />} />
-            <Route path="products/:id/edit" element={<AdminProductEdit />} />
-          </Route>
-        </Routes>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="/" element={<Top />} />
+          <Route path="/delivery" element={<Delivery />} />
+          <Route path="/products" element={<ProductList />} />
+          <Route path="/products/:id" element={<ProductDetail />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+        </Route>
+        <Route path="admin" element={<AdminLayout />}>
+          <Route path="products" element={<AdminProductList />} />
+          <Route path="products/create" element={<AdminProductCreate />} />
+          <Route path="products/:id" element={<AdminProductEdit />} />
+          <Route path="products/:id/edit" element={<AdminProductEdit />} />
+          <Route path="categories" element={<AdminCategoryList />} />
+          <Route path="categories/create" element={<AdminCategoryCreate />} />
+          <Route path="categories/:id" element={<AdminCategoryEdit />} />
+          <Route path="categories/:id/edit" element={<AdminCategoryEdit />} />
+        </Route>
+      </Routes>
     </Router>
   );
 }

--- a/client/src/components/Layout/admin/AdminHeader.tsx
+++ b/client/src/components/Layout/admin/AdminHeader.tsx
@@ -1,18 +1,23 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   NavigationMenu,
   NavigationMenuItem,
   NavigationMenuList,
-} from "@/components/ui/navigation-menu";
+} from '@/components/ui/navigation-menu';
+import { User } from 'lucide-react';
+import { Button } from '../../ui/button';
 import {
-  User,
-} from "lucide-react";
-import { Button } from "../../ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "../../ui/dropdown-menu";
-import { useAtom } from "jotai";
-import { userAtom } from "@/atoms/authAtoms";
-import { fetchUser, logout } from "@/services/authService";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../../ui/dropdown-menu';
+import { useAtom } from 'jotai';
+import { userAtom } from '@/atoms/authAtoms';
+import { fetchUser, logout } from '@/services/authService';
 
 interface User {
   id: number;
@@ -30,11 +35,11 @@ function AdminHeader() {
   useEffect(() => {
     fetchUser().then(setUser);
   }, []);
-  
+
   const handleLogoutClick = async () => {
     await logout();
     setUser(null);
-    navigate("/login");
+    navigate('/login');
   };
 
   return (
@@ -45,12 +50,20 @@ function AdminHeader() {
           <NavigationMenu className="grow w-full">
             <NavigationMenuList className="flex-wrap">
               <NavigationMenuItem>
-                <Button aria-label="Submit" variant="ghost" onClick={() => navigate("/admin/products")}>
+                <Button
+                  aria-label="Submit"
+                  variant="ghost"
+                  onClick={() => navigate('/admin/products')}
+                >
                   商品管理
                 </Button>
               </NavigationMenuItem>
               <NavigationMenuItem>
-                <Button aria-label="Submit" variant="ghost">
+                <Button
+                  aria-label="Submit"
+                  variant="ghost"
+                  onClick={() => navigate('/admin/categories')}
+                >
                   カテゴリー管理
                 </Button>
               </NavigationMenuItem>
@@ -70,16 +83,14 @@ function AdminHeader() {
                           <div className="text-gray-600">{user.email}</div>
                         </div>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={handleLogoutClick}>
-                          ログアウト
-                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={handleLogoutClick}>ログアウト</DropdownMenuItem>
                       </>
                     ) : (
                       <>
-                        <DropdownMenuItem onClick={() => navigate("/login")}>
+                        <DropdownMenuItem onClick={() => navigate('/login')}>
                           ログイン
                         </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => navigate("/signup")}>
+                        <DropdownMenuItem onClick={() => navigate('/signup')}>
                           新規登録
                         </DropdownMenuItem>
                       </>

--- a/client/src/pages/admin/AdminCategoryCreate.tsx
+++ b/client/src/pages/admin/AdminCategoryCreate.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Heading from '@/components/Heading';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { createCategory } from '@/services/admin/categoryService';
+
+const AdminCategoryCreate = () => {
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('カテゴリ名を入力してください');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = {
+        name: name.trim(),
+      };
+      await createCategory(payload);
+      navigate('/admin/categories');
+    } catch (err: unknown) {
+      console.log(err);
+      const status = (err as { status?: number })?.status;
+      if (status === 401) {
+        navigate('/login');
+        return;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg || '作成に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <Heading>カテゴリ登録</Heading>
+      </div>
+
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-sm max-w-2xl">
+        {error && <div className="text-red-600 mb-3">{error}</div>}
+
+        <div className="grid grid-cols-1 gap-4">
+          <div>
+            <Label>カテゴリ名</Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="カテゴリ名を入力してください"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 mt-2">
+            <Button type="submit" disabled={loading}>
+              登録
+            </Button>
+            <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+              キャンセル
+            </Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default AdminCategoryCreate;

--- a/client/src/pages/admin/AdminCategoryEdit.tsx
+++ b/client/src/pages/admin/AdminCategoryEdit.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Heading from '@/components/Heading';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { getCategory, updateCategory } from '@/services/admin/categoryService';
+
+const AdminCategoryEdit = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchCategory = async () => {
+      setLoading(true);
+      try {
+        const c = await getCategory(id);
+        setName(c.name || '');
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg || '取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCategory();
+  }, [id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        name: name.trim(),
+      };
+
+      await updateCategory(id, payload);
+      navigate('/admin/categories');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg || '保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-6">読み込み中...</div>;
+  }
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <Heading>カテゴリ編集</Heading>
+      </div>
+
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-sm max-w-2xl">
+        {error && <div className="text-red-600 mb-3">{error}</div>}
+
+        <div className="grid grid-cols-1 gap-4">
+          <div>
+            <Label>カテゴリ名</Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="カテゴリ名を入力してください"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 mt-2">
+            <Button type="submit" disabled={saving}>
+              保存
+            </Button>
+            <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+              キャンセル
+            </Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default AdminCategoryEdit;

--- a/client/src/pages/admin/AdminCategoryList.tsx
+++ b/client/src/pages/admin/AdminCategoryList.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import Heading from '@/components/Heading';
+import { Button } from '@/components/ui/button';
+import { Plus, Edit, Trash } from 'lucide-react';
+import type { Category as CategoryType } from '@/types/CategoryType';
+import { listCategories, deleteCategory } from '@/services/admin/categoryService';
+
+const AdminCategoryList = () => {
+  const [categories, setCategories] = useState<CategoryType[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const fetchCategories = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await listCategories();
+      setCategories(list);
+    } catch (err: unknown) {
+      console.error(err);
+      const status = (err as { status?: number })?.status;
+      if (status === 401) {
+        navigate('/login');
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || 'Failed to fetch categories');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCategories();
+  }, []);
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('本当にこのカテゴリを削除しますか？')) return;
+    try {
+      await deleteCategory(id);
+      setCategories((prev) => prev.filter((c) => c.id !== id));
+    } catch (err: unknown) {
+      console.error(err);
+      const status = (err as { status?: number })?.status;
+      if (status === 401) {
+        navigate('/login');
+        return;
+      }
+      alert('削除に失敗しました。コンソールを確認してください。');
+    }
+  };
+
+  const filtered = categories;
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <Heading>カテゴリ管理</Heading>
+        <div className="flex items-center gap-2">
+          <Link to="/admin/categories/create">
+            <Button className="flex items-center gap-2" variant="default">
+              <Plus /> 登録
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <div className="bg-white shadow rounded-md overflow-x-auto">
+        <table className="w-full table-sm">
+          <thead className="bg-gray-50 text-left">
+            <tr>
+              <th className="px-4 py-3">ID</th>
+              <th className="px-4 py-3">カテゴリ名</th>
+              <th className="px-4 py-3">作成日</th>
+              <th className="px-4 py-3">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={4} className="p-6 text-center text-gray-500">
+                  読み込み中...
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={4} className="p-6 text-center text-red-600">
+                  エラー: {error}
+                </td>
+              </tr>
+            ) : filtered.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="p-6 text-center text-gray-600">
+                  カテゴリが見つかりません。
+                </td>
+              </tr>
+            ) : (
+              filtered.map((c) => (
+                <tr key={c.id} className="border-t">
+                  <td className="px-4 py-3 align-top">{c.id}</td>
+                  <td className="px-4 py-3 align-top">
+                    <div className="font-medium">{c.name}</div>
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    {c.created_at ? new Date(c.created_at).toLocaleString() : '-'}
+                  </td>
+                  <td className="px-4 py-3 align-top">
+                    <div className="flex items-center gap-2">
+                      <Link to={`/admin/categories/${c.id}/edit`}>
+                        <Button className="flex items-center gap-2" variant="outline" size="sm">
+                          <Edit /> 編集
+                        </Button>
+                      </Link>
+                      <Button
+                        className="flex items-center gap-2"
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleDelete(c.id)}
+                      >
+                        <Trash /> 削除
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default AdminCategoryList;

--- a/client/src/services/admin/categoryService.ts
+++ b/client/src/services/admin/categoryService.ts
@@ -12,6 +12,7 @@ export const listCategories = async (): Promise<Category[]> => {
   const res = await fetch(`${API_URL}/admin/categories`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
+    credentials: 'include',
   });
 
   if (res.status === 401) throw makeError(401, 'Unauthorized');
@@ -20,10 +21,11 @@ export const listCategories = async (): Promise<Category[]> => {
   return Array.isArray(data) ? data : data.data || [];
 };
 
-export const getCategories = async (id: number | string): Promise<Category> => {
+export const getCategory = async (id: number | string): Promise<Category> => {
   const res = await fetch(`${API_URL}/admin/categories/${id}`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
+    credentials: 'include',
   });
 
   if (res.status === 401) throw makeError(401, 'Unauthorized');
@@ -33,7 +35,7 @@ export const getCategories = async (id: number | string): Promise<Category> => {
   return data && data.id ? data : data.data;
 };
 
-export const createCategories = async (payload: Partial<Category>): Promise<Category> => {
+export const createCategory = async (payload: Partial<Category>): Promise<Category> => {
   const res = await fetch(` ${API_URL}/admin/categories`, {
     method: 'POST',
     headers: {
@@ -53,7 +55,7 @@ export const createCategories = async (payload: Partial<Category>): Promise<Cate
   return await res.json();
 };
 
-export const updateCategories = async (
+export const updateCategory = async (
   id: number | string,
   payload: Partial<Category>
 ): Promise<Category> => {
@@ -76,7 +78,7 @@ export const updateCategories = async (
   return await res.json();
 };
 
-export const deleteCategories = async (id: number | string): Promise<void> => {
+export const deleteCategory = async (id: number | string): Promise<void> => {
   const res = await fetch(`${API_URL}/admin/categories/${id}`, {
     method: 'DELETE',
     headers: {

--- a/server/laravel/app/Http/Requests/StoreCategoryRequest.php
+++ b/server/laravel/app/Http/Requests/StoreCategoryRequest.php
@@ -15,7 +15,7 @@ class StoreCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255','unique:categories,name'],
             'image_url' => ['nullable', 'url'],
         ];
     }

--- a/server/laravel/app/Http/Requests/UpdateCategoryRequest.php
+++ b/server/laravel/app/Http/Requests/UpdateCategoryRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateCategoryRequest extends FormRequest
 {
@@ -14,7 +15,12 @@ class UpdateCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['sometimes', 'string', 'max:255'],
+            'name' => [
+                'required', 
+                'string', 
+                'max:255',
+                Rule::unique('categories', 'name')->ignore($this->category),
+            ],
             'image_url' => ['nullable', 'url'],
         ];
     }


### PR DESCRIPTION
# 管理画面におけるカテゴリ管理画面の実装（一覧・登録・編集・削除）

## 概要
管理者向けの「カテゴリ管理」画面群（一覧／登録／編集／削除）を実装しました。  
フロントエンド側の画面実装と、それに合わせたバリデーションの調整。

## 変更内容

### 1. カテゴリ一覧画面の追加（AdminCategoryList）
- `/admin/categories` にカテゴリ一覧を表示する画面を追加

### 2. カテゴリ登録画面の追加（AdminCategoryCreate）
- `/admin/categories/create` にカテゴリ登録画面を追加

### 3. カテゴリ編集画面の追加（AdminCategoryEdit）
- `/admin/categories/:id/edit` にカテゴリ編集画面を追加


### 4. UpdateCategoryRequest のバリデーション修正
- `app/Http/Requests/UpdateCategoryRequest.php` を修正
- カテゴリ名の一意性を担保するため、Rule::unique('categories', 'name')->ignore($this->category) を追加
- 
動作確認
	•	/admin/categories にカテゴリ一覧が表示される
	•	「カテゴリ管理」ボタンから一覧画面へ遷移できる
	•	新規登録画面からカテゴリを登録できる
	•	空欄で登録・更新した場合にエラーが返る
	•	既存と同じ名前で登録・更新した場合にユニーク制約エラーとなる
	•	編集画面で既存のカテゴリ名が正しく表示される
	•	編集後に一覧画面へリダイレクトされる
	•	削除ボタンで確認ダイアログが表示され、OK で削除される
	•	未ログイン状態でアクセスした場合は 401 → /login に遷移する