### PR TITLE
Feature/cart カートAPIの実装

### DIFF
--- a/server/laravel/app/Http/Controllers/CartController.php
+++ b/server/laravel/app/Http/Controllers/CartController.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Price;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class CartController extends Controller
+{
+    // GET /cart
+    public function index(Request $request)
+    {
+        [$cart, $cookie] = $this->resolveCart($request);
+
+        $response = response()->json($this->serializeCart($cart));
+        if ($cookie) {
+            $response->withCookie($cookie);
+        }
+
+        return $response;
+    }
+
+    // POST /cart
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'product_id' => ['required', 'exists:products,id'],
+            'price_id'   => ['required', 'exists:prices,id'],
+            'quantity'   => ['required', 'integer', 'min:1'],
+        ]);
+
+        [$cart, $cookie] = $this->resolveCart($request);
+
+        $price = Price::findOrFail($data['price_id']);
+        if ($price->product_id !== $data['product_id']) {
+            abort(422, 'price_id does not belong to the given product_id');
+        }
+
+        $item = $cart->items()
+            ->where('product_id', $data['product_id'])
+            ->where('price_id', $data['price_id'])
+            ->first();
+
+        if ($item) {
+            $item->increment('quantity', $data['quantity']);
+        } else {
+            $cart->items()->create($data);
+        }
+
+        $cart->refresh();
+
+        $response = response()->json($this->serializeCart($cart));
+        if ($cookie) {
+            $response->withCookie($cookie);
+        }
+
+        return $response;
+    }
+
+    // PUT /cart
+    public function update(Request $request)
+    {
+        $data = $request->validate([
+            'cart_item_id' => ['required', 'exists:cart_items,id'],
+            'quantity'     => ['required', 'integer', 'min:1'],
+        ]);
+
+        [$cart, $cookie] = $this->resolveCart($request);
+
+        $item = $cart->items()->where('id', $data['cart_item_id'])->firstOrFail();
+        
+        $item->update(['quantity' => $data['quantity']]);
+
+        $cart->refresh();
+
+        $response = response()->json($this->serializeCart($cart));
+        if ($cookie) {
+            $response->withCookie($cookie);
+        }
+
+        return $response;
+    }
+
+    // DELETE /cart
+    public function destroy(Request $request)
+    {
+        $data = $request->validate([
+            'cart_item_id' => ['required', 'exists:cart_items,id'],
+        ]);
+
+        [$cart, $cookie] = $this->resolveCart($request);
+
+        $item = $cart->items()->where('id', $data['cart_item_id'])->firstOrFail();
+        $item->delete();
+
+        $cart->refresh();
+
+        $response = response()->json($this->serializeCart($cart));
+        if ($cookie) {
+            $response->withCookie($cookie);
+        }
+
+        return $response;
+    }
+
+    private function resolveCart(Request $request): array
+    {
+        $cart = null;
+        $cookie = null;
+        $cart_token = $request->cookie('cart_token');
+
+        $cart = Cart::where('cart_token', $cart_token)->first();
+
+        if (!$cart) {
+            $cart = Cart::create([
+                'cart_token' => (string) Str::uuid(),
+                'user_id' => null,
+            ]);
+            $cookie = cookie('cart_token', $cart->cart_token, 60 * 24 * 30);
+        }
+
+        // ここから認証ステータスを考慮する
+        $user = Auth::user();
+        if ($user) {
+            $userCart = Cart::where('user_id', $user->id)->first();
+            if ($userCart) {
+                if ($userCart->id !== $cart->id) {
+                    $this->mergeCarts($userCart, $cart);
+                    $cart = $userCart;
+
+                    $cookie = cookie('cart_token', $cart->cart_token, 60 * 24 * 30);
+                }
+            } else {
+                $cart->user_id = $user->id;
+                $cart->save();
+            }
+        }
+
+        return [
+            $cart->load(['items.product:id,title', 'items.price:id,unit_amount']),
+            $cookie,
+        ];
+    }
+
+    private function mergeCarts(Cart $target, Cart $source): void
+    {
+        // ソースカートのアイテムをロード
+        $source->load('items');
+
+        // ターゲットカートにアイテムをマージ
+        foreach ($source->items as $item) {
+            $existing = $target->items()
+                ->where('product_id', $item->product_id)
+                ->where('price_id', $item->price_id)
+                ->first();
+
+            if ($existing) {
+                $existing->increment('quantity', $item->quantity);
+            } else {
+                $target->items()->create([
+                    'product_id' => $item->product_id,
+                    'price_id' => $item->price_id,
+                    'quantity' => $item->quantity,
+                ]);
+            }
+        }
+
+        // ソースカートを削除
+        $source->delete();
+    }
+
+    private function serializeCart(Cart $cart): array
+    {
+        $items = $cart->items->map(function (CartItem $item) {
+            return [
+                'id' => $item->id,
+                'product_id' => $item->product_id,
+                'price_id' => $item->price_id,
+                'quantity' => $item->quantity,
+                'product_title' => optional($item->product)->title,
+                'unit_amount' => optional($item->price)->unit_amount,
+            ];
+        });
+
+        return [
+            'id' => $cart->id,
+            'user_id' => $cart->user_id,
+            'cart_token' => $cart->cart_token,
+            'items' => $items,
+        ];
+    }
+}

--- a/server/laravel/app/Models/Cart.php
+++ b/server/laravel/app/Models/Cart.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Cart extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'cart_token',
+    ];
+
+    public function items()
+    {
+        return $this->hasMany(CartItem::class);
+    }
+}

--- a/server/laravel/app/Models/CartItem.php
+++ b/server/laravel/app/Models/CartItem.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CartItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'cart_id',
+        'product_id',
+        'price_id',
+        'quantity',
+    ];
+
+    public function cart()
+    {
+        return $this->belongsTo(Cart::class);
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function price()
+    {
+        return $this->belongsTo(Price::class);
+    }
+}

--- a/server/laravel/app/Models/Price.php
+++ b/server/laravel/app/Models/Price.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Price extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'product_id',
+        'stripe_price_id',
+        'unit_amount',
+        'created_at',
+    ];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/server/laravel/database/factories/CartFactory.php
+++ b/server/laravel/database/factories/CartFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cart;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class CartFactory extends Factory
+{
+    protected $model = Cart::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => null,
+            'cart_token' => (string) Str::uuid(),
+        ];
+    }
+}

--- a/server/laravel/database/factories/CartItemFactory.php
+++ b/server/laravel/database/factories/CartItemFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Price;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CartItemFactory extends Factory
+{
+    protected $model = CartItem::class;
+
+    public function definition(): array
+    {
+        $price = Price::factory()->create();
+        $cart = Cart::factory()->create();
+
+        return [
+            'cart_id' => $cart->id,
+            'product_id' => $price->product_id,
+            'price_id' => $price->id,
+            'quantity' => $this->faker->numberBetween(1, 5),
+        ];
+    }
+}

--- a/server/laravel/database/factories/PriceFactory.php
+++ b/server/laravel/database/factories/PriceFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Price;
+use App\Models\Product;
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PriceFactory extends Factory
+{
+    protected $model = Price::class;
+
+    public function definition(): array
+    {
+        $category = Category::factory()->create();
+        $product = Product::factory()->create(['category_id' => $category->id, 'status' => 'published']);
+
+        return [
+            'product_id' => $product->id,
+            'stripe_price_id' => $this->faker->numberBetween(100000, 999999),
+            'unit_amount' => $this->faker->numberBetween(500, 30000),
+            'created_at' => now(),
+        ];
+    }
+}

--- a/server/laravel/database/migrations/2025_10_21_121216_create_carts_table.php
+++ b/server/laravel/database/migrations/2025_10_21_121216_create_carts_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users')->unique();
-            $table->integer('session_id')->unique();
+            $table->foreignId('user_id')->nullable()->constrained('users')->unique();
+            $table->string('cart_token', 64)->unique();
             $table->timestamps();
         });
     }

--- a/server/laravel/database/migrations/2025_10_21_121217_create_cart_items_table.php
+++ b/server/laravel/database/migrations/2025_10_21_121217_create_cart_items_table.php
@@ -13,9 +13,9 @@ return new class extends Migration
     {
         Schema::create('cart_items', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('cart_id')->constrainde('carts');
-            $table->foreignId('product_id')->constrainde('products');
-            $table->foreignId('price_id')->constrainde('prices');
+            $table->foreignId('cart_id')->constrained('carts')->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained('products');
+            $table->foreignId('price_id')->constrained('prices');
             $table->integer('quantity');
             $table->timestamps();
         });

--- a/server/laravel/database/seeders/CartSeeder.php
+++ b/server/laravel/database/seeders/CartSeeder.php
@@ -13,6 +13,20 @@ class CartSeeder extends Seeder
      */
     public function run(): void
     {
-        //
+        // Assuming guest cart
+        DB::table('carts')->insert([
+            'user_id' => null,
+            'cart_token' => 'guest_cart_token_1234567890abcdef',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        
+        // Assuming user cart
+        DB::table('carts')->insert([
+            'user_id' => 1, 
+            'cart_token' => 'user_cart_token_1234567890abcdef',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 }

--- a/server/laravel/database/seeders/DatabaseSeeder.php
+++ b/server/laravel/database/seeders/DatabaseSeeder.php
@@ -17,12 +17,13 @@ class DatabaseSeeder extends Seeder
 
         $this->call([
             UserSeeder::class,
-            CartItemSeeder::class,
             CategorySeeder::class,
             FavoriteSeeder::class,
             ProductSeeder::class,
             PriceSeeder::class,
-             OrderSeeder::class,
+            CartSeeder::class,
+            CartItemSeeder::class,
+            OrderSeeder::class,
             OrderItemSeeder::class,
             InventorySeeder::class,
             ReviewSeeder::class,

--- a/server/laravel/routes/web.php
+++ b/server/laravel/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CategoryController as PublicCategory;
 use App\Http\Controllers\ProductController as PublicProduct;
 use App\Http\Controllers\Admin\CategoryController as AdminCategory;
 use App\Http\Controllers\Admin\ProductController as AdminProduct;
+use App\Http\Controllers\CartController;
 use App\Http\Controllers\Admin;
 
 Route::get('/', function () {
@@ -24,6 +25,12 @@ Route::get('/products/{id}',   [PublicProduct::class, 'show']);
 // カテゴリ管理（一般公開・閲覧用）
 Route::get('/categories',        [PublicCategory::class, 'index']);
 Route::get('/categories/{id}',   [PublicCategory::class, 'show']);
+
+// カート
+Route::get('/cart',    [CartController::class, 'index']);
+Route::post('/cart',   [CartController::class, 'store']);
+Route::put('/cart',    [CartController::class, 'update']);
+Route::delete('/cart', [CartController::class, 'destroy']);
 
 
 // 認証が必要なルート

--- a/server/laravel/tests/Feature/CartControllerTest.php
+++ b/server/laravel/tests/Feature/CartControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Cart;
+use App\Models\Category;
+use App\Models\Price;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CartControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createProductAndPrice(): array
+    {
+        $category = Category::factory()->create();
+        $product = Product::factory()->create([
+            'category_id' => $category->id,
+            'status' => 'published',
+        ]);
+        $price = Price::create([
+            'product_id' => $product->id,
+            'stripe_price_id' => 123456,
+            'unit_amount' => 1200,
+            'created_at' => now(),
+        ]);
+
+        return [$product, $price];
+    }
+
+    public function test_guest_can_add_item_and_receive_cart_token_cookie(): void
+    {
+        [$product, $price] = $this->createProductAndPrice();
+
+        $response = $this->postJson('/cart', [
+            'product_id' => $product->id,
+            'price_id' => $price->id,
+            'quantity' => 2,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertCookie('cart_token')
+            ->assertJsonFragment([
+                'product_id' => $product->id,
+                'price_id' => $price->id,
+                'quantity' => 2,
+            ]);
+
+        $this->assertDatabaseHas('cart_items', [
+            'product_id' => $product->id,
+            'price_id' => $price->id,
+            'quantity' => 2,
+        ]);
+    }
+
+    public function test_guest_can_update_and_delete_cart_items_via_cart_item_id(): void
+    {
+        [$product, $price] = $this->createProductAndPrice();
+
+        $createResponse = $this->postJson('/cart', [
+            'product_id' => $product->id,
+            'price_id' => $price->id,
+            'quantity' => 1,
+        ]);
+        
+        $token = $createResponse->getCookie('cart_token')->getValue();
+
+        $itemId = $createResponse->json('items.0.id');
+        
+        $updateResponse = $this->withCookie('cart_token', $token)->withCredentials()->putJson('/cart', [
+            'cart_item_id' => $itemId,
+            'quantity' => 4,
+        ]);
+
+        $updateResponse->assertStatus(200)
+            ->assertJsonFragment([
+                'id' => $itemId,
+                'quantity' => 4,
+            ]);
+
+        $deleteResponse = $this->withCookie('cart_token', $token)->withCredentials()->deleteJson('/cart', [
+            'cart_item_id' => $itemId,
+        ]);
+
+        $deleteResponse->assertStatus(200)
+            ->assertJson([
+                'items' => [],
+            ]);
+
+        $this->assertDatabaseMissing('cart_items', ['id' => $itemId]);
+    }
+
+    public function test_guest_cart_merges_into_user_cart_on_login(): void
+    {
+        [$guestProduct, $guestPrice] = $this->createProductAndPrice();
+
+        $guestResponse = $this->postJson('/cart', [
+            'product_id' => $guestProduct->id,
+            'price_id' => $guestPrice->id,
+            'quantity' => 2,
+        ]);
+
+        $guestToken = $guestResponse->getCookie('cart_token')->getValue();
+
+        [$userProduct, $userPrice] = $this->createProductAndPrice();
+        $user = User::factory()->create();
+
+        $userCart = Cart::factory()->create([
+            'user_id' => $user->id,
+            'cart_token' => (string) Str::uuid(),
+        ]);
+        $userCart->items()->create([
+            'product_id' => $userProduct->id,
+            'price_id' => $userPrice->id,
+            'quantity' => 1,
+        ]);
+
+        $response = $this->withCookie('cart_token', $guestToken)->withCredentials()
+            ->actingAs($user)
+            ->getJson('/cart');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['user_id' => $user->id])
+            ->assertJsonFragment([
+                'product_id' => $guestProduct->id,
+                'quantity' => 2,
+            ])
+            ->assertJsonFragment([
+                'product_id' => $userProduct->id,
+                'quantity' => 1,
+            ]);
+
+        $this->assertDatabaseHas('carts', ['user_id' => $user->id]);
+        $this->assertDatabaseMissing('carts', ['cart_token' => $guestToken]);
+    }
+}


### PR DESCRIPTION
## 概要
- カート操作APIの実装
- カート操作APIのFeatureテストの実装

## 変更内容
- DBスキーマ変更
  - カートの識別子をsession_idからcart_tokenに変更
  - user_idをnullableに変更
- マイグレーションファイルに存在していた外部キー制約のタイポを修正
- マイグレーションとシーダーの実行順序を変更
- モデル追加
  - Cart / CartItem / Price
- コントローラー追加
  - カート取得、アイテム追加、アイテム更新（数量更新）、カートアイテム削除
- コントローラテスト追加 
## 動作確認
### CartControllerTestに三つのテストケースを追加
1. ゲストモードでカートにアイテムを追加できるか
2. ゲストモードでカートにアイテムを追加し、更新、削除できるか
3. ゲストモードでカートにアイテムを追加し、ログインした場合にカート内容をマージして引き継げるか
### テスト実行コマンド
```
php artisan test --filter=CartControllerTest
```

## 補足
カート画面ができ次第フロントとバックのAPI連携が必要。