### PR TITLE
Feature/favorite page お気に入り機能追加

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import ProductDetail from './pages/ProductDetail';
 import AdminCategoryList from '@/pages/admin/AdminCategoryList';
 import AdminCategoryCreate from '@/pages/admin/AdminCategoryCreate';
 import AdminCategoryEdit from '@/pages/admin/AdminCategoryEdit';
+import FavoriteList from './pages/favoriteList';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
           <Route path="/delivery" element={<Delivery />} />
           <Route path="/products" element={<ProductList />} />
           <Route path="/products/:id" element={<ProductDetail />} />
+          <Route path="/favorites" element={<FavoriteList />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
         </Route>

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -1,27 +1,25 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   NavigationMenu,
   NavigationMenuItem,
   NavigationMenuList,
-} from "@/components/ui/navigation-menu";
-import { Input } from "@/components/ui/input";
+} from '@/components/ui/navigation-menu';
+import { Input } from '@/components/ui/input';
+import { ChevronRight, Coins, Heart, History, Search, ShoppingCart, User } from 'lucide-react';
+import { Button } from '../ui/button';
 import {
-  ChevronRight,
-  Coins,
-  Heart,
-  History,
-  Search,
-  ShoppingCart,
-  User,
-} from "lucide-react";
-import { Button } from "../ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu";
-import type { User as UserType } from "@/types/authTypes";
-import { useAtom } from "jotai";
-import { userAtom } from "@/atoms/authAtoms";
-import { fetchUser, logout } from "@/services/authService";
-
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import type { User as UserType } from '@/types/authTypes';
+import { useAtom } from 'jotai';
+import { userAtom } from '@/atoms/authAtoms';
+import { fetchUser, logout } from '@/services/authService';
 
 function Header() {
   const [user, setUser] = useAtom(userAtom);
@@ -34,7 +32,11 @@ function Header() {
   const handleLogoutClick = async () => {
     await logout();
     setUser(null);
-    navigate("/login");
+    navigate('/login');
+  };
+
+  const handleFavoriteClick = () => {
+    navigate('/favorites');
   };
 
   return (
@@ -46,10 +48,7 @@ function Header() {
             <NavigationMenuList className="flex-wrap">
               <NavigationMenuItem>
                 <div className="relative w-full max-w-sm">
-                  <Input
-                    className="placeholder:text-gray-400  pr-10"
-                    placeholder="検索"
-                  />
+                  <Input className="placeholder:text-gray-400  pr-10" placeholder="検索" />
                   <Button
                     size="icon-sm"
                     aria-label="Submit"
@@ -71,7 +70,12 @@ function Header() {
                 </Button>
               </NavigationMenuItem>
               <NavigationMenuItem>
-                <Button size="icon-sm" aria-label="Submit" variant="ghost">
+                <Button
+                  size="icon-sm"
+                  aria-label="Submit"
+                  variant="ghost"
+                  onClick={handleFavoriteClick}
+                >
                   <Heart />
                 </Button>
               </NavigationMenuItem>
@@ -91,16 +95,14 @@ function Header() {
                           <div className="text-gray-600">{user.email}</div>
                         </div>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={handleLogoutClick}>
-                          ログアウト
-                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={handleLogoutClick}>ログアウト</DropdownMenuItem>
                       </>
                     ) : (
                       <>
-                        <DropdownMenuItem onClick={() => navigate("/login")}>
+                        <DropdownMenuItem onClick={() => navigate('/login')}>
                           ログイン
                         </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => navigate("/signup")}>
+                        <DropdownMenuItem onClick={() => navigate('/signup')}>
                           新規登録
                         </DropdownMenuItem>
                       </>

--- a/client/src/pages/FavoriteList.tsx
+++ b/client/src/pages/FavoriteList.tsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import Heading from '@/components/Heading';
+import { listFavorites, removeFavorite, addFavorite } from '@/services/favoriteService';
+import { Heart, Star } from 'lucide-react';
+import type { FavoriteProduct } from '@/types/FavoriteType';
+
+const ProductCard = ({
+  product,
+  isFavorite,
+  onToggleFavorite,
+}: {
+  product: FavoriteProduct;
+  isFavorite: boolean;
+  onToggleFavorite: () => void;
+}) => {
+  return (
+    <div className="bg-white border shadow-sm hover:shadow-md transition p-3">
+      <img
+        src={product.imageUrl || 'https://via.placeholder.com/150'}
+        alt={product.title}
+        className="w-full h-32 object-cover rounded-md mb-3"
+      />
+      <h3 className="text-sm font-semibold text-gray-800">{product.title}</h3>
+
+      <div className="flex items-center justify-between mt-1">
+        <div className="flex text-yellow-500 text-sm">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Star
+              key={i}
+              className={`h-4 w-4 ${i < 4 ? 'fill-yellow-500' : 'fill-gray-200 text-gray-300'}`}
+            />
+          ))}
+        </div>
+
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleFavorite();
+          }}
+          className="ml-2"
+        >
+          <Heart size={24} className={isFavorite ? 'fill-red-500 text-red-500' : 'text-gray-400'} />
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-600 mt-2 leading-snug">{product.description}</p>
+    </div>
+  );
+};
+
+const FavoritePage = () => {
+  const [favoriteProducts, setFavoriteProducts] = useState<FavoriteProduct[]>([]);
+  const [favoriteIds, setFavoriteIds] = useState<number[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFavorites = async () => {
+      try {
+        const list = await listFavorites();
+
+        const ids = list.map((f) => Number(f.pivot?.product_id)).filter((n) => Number.isFinite(n));
+
+        setFavoriteProducts(list as any[]);
+        setFavoriteIds(ids);
+      } catch (err) {
+        console.error('Failed to load favorites:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFavorites();
+  }, []);
+
+  const handleToggleFavorite = async (productId: number) => {
+    try {
+      const isFav = favoriteIds.includes(productId);
+      if (isFav) {
+        await removeFavorite(productId);
+        setFavoriteIds((prev) => prev.filter((id) => id !== productId));
+      } else {
+        await addFavorite(productId);
+        setFavoriteIds((prev) => [...prev, productId]);
+      }
+    } catch (err) {
+      console.error('Failed to remove favorite:', err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <>
+        <div className="p-10 text-center">読み込み中...</div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="w-full min-h-screen bg-gray-50">
+        <div className="max-w-6xl mx-auto px-4 py-10">
+          <Heading>お気に入り</Heading>
+          <p className="text-sm text-gray-600 mt-2">お気に入りに登録した商品一覧です。</p>
+
+          <div className="mt-6 bg-white border rounded-lg shadow-sm p-6">
+            {favoriteProducts.length === 0 ? (
+              <div className="text-center text-gray-600 py-10">
+                お気に入りに登録された商品はありません。
+              </div>
+            ) : (
+              <div className="grid grid-cols-4 gap-6">
+                {favoriteProducts.map((product) => (
+                  <Link
+                    key={product.id}
+                    to={`/products/${product.id}`}
+                    className="hover:opacity-90 transition"
+                  >
+                    <ProductCard
+                      product={product}
+                      isFavorite={favoriteIds.includes(product.id)}
+                      onToggleFavorite={() => handleToggleFavorite(product.id)}
+                    />
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FavoritePage;

--- a/client/src/pages/FavoriteList.tsx
+++ b/client/src/pages/FavoriteList.tsx
@@ -84,8 +84,8 @@ const FavoritePage = () => {
         await addFavorite(productId);
         setFavoriteIds((prev) => [...prev, productId]);
       }
-    } catch (err) {
-      console.error('Failed to remove favorite:', err);
+    } catch (err: any) {
+      console.error('Failed to update favorite:', err);
     }
   };
 
@@ -132,5 +132,4 @@ const FavoritePage = () => {
     </>
   );
 };
-
 export default FavoritePage;

--- a/client/src/pages/ProductList.tsx
+++ b/client/src/pages/ProductList.tsx
@@ -77,15 +77,22 @@ const ProductList = () => {
 
   const handleToggleFavorite = async (productId: number) => {
     try {
-      if (favoriteIds.includes(productId)) {
+      const isFav = favoriteIds.includes(productId);
+      if (isFav) {
         await removeFavorite(productId);
         setFavoriteIds((prev) => prev.filter((id) => id !== productId));
       } else {
         await addFavorite(productId);
         setFavoriteIds((prev) => [...prev, productId]);
       }
-    } catch (err) {
-      console.error('お気に入りの更新に失敗しました', err);
+    } catch (err: any) {
+      const status = err?.response?.status ?? err?.status;
+      if (status === 401) {
+        alert('お気に入りの更新にはログインが必要です。');
+      } else {
+        alert('お気に入りの更新に失敗しました。');
+      }
+      console.error('Failed to toggle favorite:', err);
     }
   };
   useEffect(() => {
@@ -274,5 +281,4 @@ const ProductList = () => {
     </div>
   );
 };
-
 export default ProductList;

--- a/client/src/pages/ProductList.tsx
+++ b/client/src/pages/ProductList.tsx
@@ -1,56 +1,134 @@
-import { Link } from "react-router-dom";
-import Heading from "@/components/Heading";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Star } from "lucide-react";
+import { Link } from 'react-router-dom';
+import Heading from '@/components/Heading';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Star } from 'lucide-react';
+import { Heart } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import type { Product } from '@/types/ProductType';
+import type { Category } from '@/types/CategoryType';
+import { listPublicProducts } from '@/services/productService';
+import { listPublicCategories } from '@/services/categoryService';
+import { addFavorite, removeFavorite, listFavorites } from '@/services/favoriteService';
 
 // ページ専用 ProductCard コンポーネント
 const ProductCard = ({
   title,
   description,
   imageUrl,
-  rating,
+  rating = 4,
+  isFavorite,
+  onToggleFavorite,
 }: {
   title: string;
   description: string;
   imageUrl: string;
-  rating: number;
+  rating?: number;
+  isFavorite?: boolean;
+  onToggleFavorite?: () => void;
 }) => {
   return (
     <div className="bg-white border shadow-sm hover:shadow-md transition p-3">
       <img
-        src={imageUrl || "https://via.placeholder.com/150"}
+        src={imageUrl || 'https://via.placeholder.com/150'}
         alt={title}
         className="w-full h-32 object-cover rounded-md mb-3"
       />
       <h3 className="text-sm font-semibold text-gray-800">{title}</h3>
-
-      <div className="flex items-center text-yellow-500 text-sm mt-1">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <Star
-            key={i}
-            className={`h-4 w-4 ${
-              i < rating ? "fill-yellow-500" : "fill-gray-200 text-gray-300"
-            }`}
-          />
-        ))}
+      <div className="flex items-center justify-between mt-1">
+        <div className="flex items-center text-yellow-500 text-sm mt-1">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Star
+              key={i}
+              className={`h-4 w-4 ${
+                i < rating ? 'fill-yellow-500' : 'fill-gray-200 text-gray-300'
+              }`}
+            />
+          ))}
+        </div>
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleFavorite && onToggleFavorite();
+          }}
+          className="ml-2"
+        >
+          <Heart size={24} className={isFavorite ? 'fill-red-500 text-red-500' : 'text-gray-400'} />
+        </button>
       </div>
-
       <p className="text-xs text-gray-600 mt-2 leading-snug">{description}</p>
     </div>
   );
 };
 
 const ProductList = () => {
-  const products = Array.from({ length: 20 }).map((_, i) => ({
-    id: i + 1,
-    title: `商品名が入ります`,
-    description:
-      "商品説明や値段が入ります。商品説明や値段が入ります。",
-    imageUrl: "",
-    rating: Math.floor(Math.random() * 5) + 1,
-  }));
+  const [products, setProducts] = useState<Product[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [favoriteIds, setFavoriteIds] = useState<number[]>([]);
+
+  const filteredProducts = selectedCategoryId
+    ? products.filter((p) => p.category_id === selectedCategoryId)
+    : products;
+
+  const handleToggleFavorite = async (productId: number) => {
+    try {
+      if (favoriteIds.includes(productId)) {
+        await removeFavorite(productId);
+        setFavoriteIds((prev) => prev.filter((id) => id !== productId));
+      } else {
+        await addFavorite(productId);
+        setFavoriteIds((prev) => [...prev, productId]);
+      }
+    } catch (err) {
+      console.error('お気に入りの更新に失敗しました', err);
+    }
+  };
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [productList, categoryList, favoriteList] = await Promise.all([
+          listPublicProducts(),
+          listPublicCategories(),
+          listFavorites().catch((e) => {
+            console.error('Failed to fetch favorites', e);
+            return [];
+          }),
+        ]);
+        setProducts(productList);
+        setCategories(categoryList as Category[]);
+        const initialFavoriteIds = favoriteList
+          .map((f) => Number((f as any).pivot?.product_id))
+          .filter((n) => Number.isFinite(n));
+        setFavoriteIds(initialFavoriteIds);
+      } catch (err: unknown) {
+        console.error(err);
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message || 'データの取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const selectedCategoryName = selectedCategoryId
+    ? categories.find((c) => c.id === selectedCategoryId)?.name ?? 'カテゴリ'
+    : 'すべての商品';
+
+  if (loading) {
+    return <div className="p-6">読み込み中...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-600">エラーが発生しました：{error}</div>;
+  }
 
   return (
     <div className="w-full grid grid-cols-5 gap-8">
@@ -63,17 +141,11 @@ const ProductList = () => {
               <Label className="text-sm text-gray-600">価格帯</Label>
               <div className="flex flex-col gap-2 mt-2">
                 <div className="flex items-center gap-2">
-                  <Input
-                    placeholder="下限なし"
-                    className="w-full text-sm bg-white"
-                  />
+                  <Input placeholder="下限なし" className="w-full text-sm bg-white" />
                   <span className="text-sm text-gray-600">円〜</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Input
-                    placeholder="上限なし"
-                    className="w-full text-sm bg-white"
-                  />
+                  <Input placeholder="上限なし" className="w-full text-sm bg-white" />
                   <span className="text-sm text-gray-600">円〜</span>
                 </div>
               </div>
@@ -83,19 +155,24 @@ const ProductList = () => {
 
         <section className="mb-6">
           <Heading>カテゴリ</Heading>
-          <div className="flex gap-2 mt-3">
+          <div className="flex flex-col gap-2 mt-3">
             <Button
-              variant="outline"
-              className="flex-1 text-sm text-white bg-black"
+              variant={selectedCategoryId === null ? 'default' : 'outline'}
+              className="flex-1 text-sm  text-white bg-black"
+              onClick={() => setSelectedCategoryId(null)}
             >
-              カテゴリ名
+              全て
             </Button>
-            <Button
-              variant="outline"
-              className="flex-1 text-sm text-white bg-black"
-            >
-              カテゴリ名
-            </Button>
+            {categories.map((category) => (
+              <Button
+                key={category.id}
+                variant={selectedCategoryId === category.id ? 'default' : 'outline'}
+                className="flex-1 text-sm text-white bg-black"
+                onClick={() => setSelectedCategoryId(category.id)}
+              >
+                {category.name}
+              </Button>
+            ))}
           </div>
         </section>
 
@@ -133,9 +210,7 @@ const ProductList = () => {
         </section>
 
         <section className="mt-8 flex flex-col gap-3">
-          <Button className="w-full bg-black text-white rounded text-sm">
-            この表示で検索する
-          </Button>
+          <Button className="w-full bg-black text-white rounded text-sm">この表示で検索する</Button>
           <Button variant="outline" className="w-full text-sm">
             クリア
           </Button>
@@ -149,32 +224,40 @@ const ProductList = () => {
         </div>
 
         <div className="mb-4 px-4 mt-4">
-          <Heading>カテゴリ名</Heading>
+          <Heading>{selectedCategoryName}</Heading>
         </div>
 
         {/* 商品カード */}
         <div className="bg-white p-6 grid grid-cols-4 gap-6 rounded-md flex-1">
-          {products.map((product) => (
-            <Link
-              key={product.id}
-              to={`/products/${product.id}`}
-              className="hover:opacity-90 transition"
-            >
-              <ProductCard
-                title={product.title}
-                description={product.description}
-                imageUrl={product.imageUrl}
-                rating={product.rating}
-              />
-            </Link>
-          ))}
+          {filteredProducts.length === 0 ? (
+            <div className="col-span-4 text-center text-gray-600">
+              該当する商品が見つかりません。
+            </div>
+          ) : (
+            filteredProducts.map((product) => {
+              return (
+                <Link
+                  key={product.id}
+                  to={`/products/${product.id}`}
+                  className="hover:opacity-90 transition"
+                >
+                  <ProductCard
+                    title={product.title}
+                    description={product.description}
+                    imageUrl={product.imageUrl ?? 'https://via.placeholder.com/150'}
+                    isFavorite={favoriteIds.includes(Number(product.id))}
+                    onToggleFavorite={() => handleToggleFavorite(product.id)}
+                    // rating={product.rating}
+                  />
+                </Link>
+              );
+            })
+          )}
         </div>
 
         {/* ページネーション */}
         <div className="flex items-center justify-center gap-2 mt-6 mb-10">
-          <button className="text-sm px-3 bg-white transition cursor-pointer">
-            &lt;
-          </button>
+          <button className="text-sm px-3 bg-white transition cursor-pointer">&lt;</button>
 
           {[1, 2, 3, 4, 5].map((num) => (
             <button
@@ -185,9 +268,7 @@ const ProductList = () => {
             </button>
           ))}
 
-          <button className="text-sm px-3 bg-white transition cursor-pointer">
-            &gt;
-          </button>
+          <button className="text-sm px-3 bg-white transition cursor-pointer">&gt;</button>
         </div>
       </div>
     </div>

--- a/client/src/services/favoriteService.ts
+++ b/client/src/services/favoriteService.ts
@@ -1,5 +1,5 @@
-import type { Favorite } from '@/types/FavoriteType';
-// import { getCsrfToken } from '@/lib/utils';
+import type { FavoriteProduct } from '@/types/FavoriteType';
+import { getCsrfToken } from '@/lib/utils';
 import { API_URL } from '@/config/api';
 
 function makeError(status: number, message?: string) {
@@ -8,7 +8,7 @@ function makeError(status: number, message?: string) {
   return err;
 }
 
-export const listFavorites = async (): Promise<Favorite[]> => {
+export const listFavorites = async (): Promise<FavoriteProduct[]> => {
   const res = await fetch(`${API_URL}/favorites`, {
     method: 'GET',
     headers: { Accept: 'application/json' },
@@ -22,13 +22,13 @@ export const listFavorites = async (): Promise<Favorite[]> => {
   return Array.isArray(data) ? data : data.data || [];
 };
 
-export const addFavorite = async (productId: number | string): Promise<Favorite> => {
+export const addFavorite = async (productId: number | string): Promise<FavoriteProduct> => {
   const res = await fetch(`${API_URL}/favorites`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      // 'X-XSRF-TOKEN': getCsrfToken() ?? '',
+      'X-XSRF-TOKEN': getCsrfToken() ?? '',
     },
     credentials: 'include',
     body: JSON.stringify({ product_id: productId }),
@@ -46,7 +46,7 @@ export const removeFavorite = async (productId: number | string): Promise<void> 
     method: 'DELETE',
     headers: {
       Accept: 'application/json',
-      // 'X-XSRF-TOKEN': getCsrfToken() ?? '',
+      'X-XSRF-TOKEN': getCsrfToken() ?? '',
     },
     credentials: 'include',
   });

--- a/client/src/services/favoriteService.ts
+++ b/client/src/services/favoriteService.ts
@@ -1,0 +1,63 @@
+import type { Favorite } from '@/types/FavoriteType';
+// import { getCsrfToken } from '@/lib/utils';
+import { API_URL } from '@/config/api';
+
+function makeError(status: number, message?: string) {
+  const err: Error & { status?: number } = new Error(message || `HTTP ${status}`);
+  err.status = status;
+  return err;
+}
+
+export const listFavorites = async (): Promise<Favorite[]> => {
+  const res = await fetch(`${API_URL}/favorites`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  });
+
+  if (res.status === 401) throw makeError(401, 'Unauthorized');
+  if (!res.ok) throw makeError(res.status);
+
+  const data = await res.json();
+  return Array.isArray(data) ? data : data.data || [];
+};
+
+export const addFavorite = async (productId: number | string): Promise<Favorite> => {
+  const res = await fetch(`${API_URL}/favorites`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      // 'X-XSRF-TOKEN': getCsrfToken() ?? '',
+    },
+    credentials: 'include',
+    body: JSON.stringify({ product_id: productId }),
+  });
+  if (res.status === 401) throw makeError(401, 'Unauthorized');
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw makeError(res.status, body.message || `HTTP ${res.status}`);
+  }
+  return await res.json();
+};
+
+export const removeFavorite = async (productId: number | string): Promise<void> => {
+  const res = await fetch(`${API_URL}/favorites/${productId}`, {
+    method: 'DELETE',
+    headers: {
+      Accept: 'application/json',
+      // 'X-XSRF-TOKEN': getCsrfToken() ?? '',
+    },
+    credentials: 'include',
+  });
+
+  if (res.status === 401) {
+    throw makeError(401, 'Unauthorized');
+  }
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw makeError(res.status, body.message || `HTTP ${res.status}`);
+  }
+
+  return await res.json();
+};

--- a/client/src/types/FavoriteType.ts
+++ b/client/src/types/FavoriteType.ts
@@ -1,0 +1,6 @@
+export interface Favorite {
+  id: number;
+  user_id: number;
+  product_id: number;
+  created_at?: string | null;
+}

--- a/client/src/types/FavoriteType.ts
+++ b/client/src/types/FavoriteType.ts
@@ -1,6 +1,22 @@
+import type { Product } from './ProductType';
+
+// favorites テーブル1行分（中間テーブルのレコード）
 export interface Favorite {
   id: number;
   user_id: number;
   product_id: number;
   created_at?: string | null;
+  updated_at?: string | null;
 }
+// /favorites のレスポンスに含まれる pivot 部分
+export interface FavoritePivot {
+  user_id: number;
+  product_id: number;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+// /favorites のレスポンス1件分（Product + pivot）
+export type FavoriteProduct = Product & {
+  pivot: FavoritePivot;
+};

--- a/client/src/types/ProductType.ts
+++ b/client/src/types/ProductType.ts
@@ -1,7 +1,7 @@
 export interface Product {
   id: number;
   title: string;
-  description?: string | null;
+  description: string;
   category_id?: number | null;
   status?: string | null;
   imageUrl?: string | null;

--- a/server/laravel/app/Http/Controllers/FavoriteController.php
+++ b/server/laravel/app/Http/Controllers/FavoriteController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\FavoriteStoreRequest;
+
+class FavoriteController extends Controller
+{
+    //
+    // public function __construct()
+    // {
+    //     $this->middleware('auth:sanctum');
+    // }
+
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $favorites = $user->favoriteProducts()->with('category')->get();
+
+        return response()->json($favorites);
+    }
+
+    public function store(FavoriteStoreRequest $request)
+    {
+        $user = $request->user();
+        $validated = $request->validated();
+
+        $user->favoriteProducts()->syncWithoutDetaching([
+        $validated['product_id']]); 
+        return response()->json(['message' => 'お気に入りに追加しました。'], 201);       
+    }
+
+    public function destroy(Request $request, $productId)
+    {
+        $user = $request->user();
+
+        $user->favoriteProducts()->detach($productId);
+
+        return response()->json(['message' => 'お気に入りから削除しました。']);
+    }
+}

--- a/server/laravel/app/Http/Controllers/FavoriteController.php
+++ b/server/laravel/app/Http/Controllers/FavoriteController.php
@@ -7,12 +7,6 @@ use App\Http\Requests\FavoriteStoreRequest;
 
 class FavoriteController extends Controller
 {
-    //
-    // public function __construct()
-    // {
-    //     $this->middleware('auth:sanctum');
-    // }
-
     public function index(Request $request)
     {
         $user = $request->user();

--- a/server/laravel/app/Http/Requests/FavoriteStoreRequest.php
+++ b/server/laravel/app/Http/Requests/FavoriteStoreRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FavoriteStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'product_id' => ['required', 'integer', 'exists:products,id'],
+        ];
+    }
+}

--- a/server/laravel/app/Http/Resources/ProductResource.php
+++ b/server/laravel/app/Http/Resources/ProductResource.php
@@ -18,6 +18,7 @@ class ProductResource extends JsonResource
             'id'          => $this->id,
             'title'       => $this->title,
             'description' => $this->description,
+            'category_id' => $this->category_id,
             'status'      => $this->status,
             'released_at' => optional($this->released_at)->toDateString(),
         ];

--- a/server/laravel/app/Models/Product.php
+++ b/server/laravel/app/Models/Product.php
@@ -35,7 +35,13 @@ class Product extends Model
     }
 
     public function category()
-{
-    return $this->belongsTo(Category::class);
-}
+    {
+        return $this->belongsTo(Category::class);
+    }
+    
+    public function favoritedByUsers()
+    {
+        return $this->belongsToMany(User::class, 'favorites')
+            ->withTimestamps();
+    }
 }

--- a/server/laravel/app/Models/User.php
+++ b/server/laravel/app/Models/User.php
@@ -49,4 +49,11 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function favoriteProducts()
+    {
+        return $this->belongsToMany(Product::class, 'favorites')
+            ->withTimestamps()
+            ->withPivot('created_at');
+    }
 }

--- a/server/laravel/database/migrations/2025_10_21_121217_create_favorites_table.php
+++ b/server/laravel/database/migrations/2025_10_21_121217_create_favorites_table.php
@@ -12,11 +12,18 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('favorites', function (Blueprint $table) {
-            $table->bigInteger('user_id')->constrained('users');
-            $table->bigInteger('product_id')->constrained('products');
-            $table->timestamp('created_at')->nullable();
+            $table->id();
+            $table->foreignId('user_id')
+                ->constrained()
+                ->cascadeOnDelete();
 
-            $table->primary(['user_id', 'product_id']);
+            $table->foreignId('product_id')
+                ->constrained()
+                ->cascadeOnDelete();
+
+            $table->timestamps();
+
+            $table->unique(['user_id', 'product_id']);
         });
     }
 

--- a/server/laravel/database/seeders/DatabaseSeeder.php
+++ b/server/laravel/database/seeders/DatabaseSeeder.php
@@ -18,8 +18,8 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             CategorySeeder::class,
-            FavoriteSeeder::class,
             ProductSeeder::class,
+            FavoriteSeeder::class,
             PriceSeeder::class,
             CartSeeder::class,
             CartItemSeeder::class,

--- a/server/laravel/database/seeders/ProductSeeder.php
+++ b/server/laravel/database/seeders/ProductSeeder.php
@@ -44,6 +44,51 @@ class ProductSeeder extends Seeder
                 ]),
                 'released_at' => now()->subDay(),
             ],
+            [
+                'title' => 'sample_product_one',
+                'description' => 'first sample seeded product',
+                'default_price_id' => null,
+                'status' => 'published',
+                'category_id' => 2,
+                'creator' => 'system',
+                'stripe_product_id' => 3,
+                'seo_tags' => json_encode([
+                    'title' => 'サンプル商品1',
+                    'description' => 'これはサンプル商品1の説明です。',
+                    'image' => 'https://example.com/images/sample1.jpg',
+                ]),
+                'released_at' => now()->subDays(2),
+            ],
+            [
+                'title' => 'sample_product_two',
+                'description' => 'second sample seeded product',
+                'default_price_id' => null,
+                'status' => 'draft',
+                'category_id' => 2,
+                'creator' => 'system',
+                'stripe_product_id' => 4,
+                'seo_tags' => json_encode([
+                    'title' => 'サンプル商品2',
+                    'description' => 'これはサンプル商品2の説明です。',
+                    'image' => 'https://example.com/images/sample2.jpg',
+                ]),
+                'released_at' => null,
+            ],
+            [
+                'title' => 'premium_sample_product',
+                'description' => 'premium level sample product',
+                'default_price_id' => null,
+                'status' => 'published',
+                'category_id' => 3,
+                'creator' => 'system',
+                'stripe_product_id' => 5,
+                'seo_tags' => json_encode([
+                    'title' => 'プレミアムサンプル商品',
+                    'description' => '高品質なプレミアムサンプル商品の紹介です。',
+                    'image' => 'https://example.com/images/sample3.jpg',
+                ]),
+                'released_at' => now(),
+            ],
         ]);
     }
 }

--- a/server/laravel/routes/web.php
+++ b/server/laravel/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CategoryController as PublicCategory;
 use App\Http\Controllers\ProductController as PublicProduct;
 use App\Http\Controllers\Admin\CategoryController as AdminCategory;
 use App\Http\Controllers\Admin\ProductController as AdminProduct;
+use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\Admin;
 
 Route::get('/', function () {
@@ -32,6 +33,11 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/user', function (Request $request) {
         return $request->user();
     });
+
+    // お気に入り機能
+    Route::get('/favorites', [FavoriteController::class, 'index']);
+    Route::post('/favorites', [FavoriteController::class, 'store']);
+    Route::delete('/favorites/{productId}', [FavoriteController::class, 'destroy']);
 
     // 商品CRUD API
     Route::middleware('role:admin')->prefix('admin')->group(function () {

--- a/server/laravel/tests/Feature/FavoriteControllerTest.php
+++ b/server/laravel/tests/Feature/FavoriteControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Product;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+
+class FavoriteControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A basic feature test example.
+     */
+    public function test_guest_cannnot_access_favorites()
+    {
+        $this->getJson('/favorites')->assertUnauthorized();
+        $this->postJson('/favorites',['product_id' => 1])->assertUnauthorized();
+        $this->deleteJson('/favorites/1')->assertUnauthorized();
+    }
+
+    public function test_user_can_get_own_favorites()
+    {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        //外部キー制約があるから、カテゴリも作成する
+        $category = Category::factory()->create();
+
+        $productA = Product::factory()->create([
+        'category_id' => $category->id,
+        ]);
+        $productB = Product::factory()->create([
+            'category_id' => $category->id,
+        ]);
+
+        $userA->favoriteProducts()->syncWithoutDetaching([$productA->id]);
+        $userB->favoriteProducts()->syncWithoutDetaching([$productB->id]);
+
+        $res = $this->actingAs($userA,'sanctum')->getJson('/favorites');
+        $res->assertOk()->assertJsonFragment([
+            'id' => $productA->id,
+        ])->assertJsonMissing([
+            'id' => $productB->id,
+        ]);
+    }
+
+    public function test_user_can_add_favorite()
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+        $product = Product::factory()->create([
+        'category_id' => $category->id,
+        ]);
+
+        $res = $this->actingAs($user,'sanctum')->postJson('/favorites',[
+            'product_id' => $product->id,
+        ]);
+
+        $res->assertCreated()->assertJson([
+            'message' => 'お気に入りに追加しました。',
+        ]);
+
+        $this->assertDatabaseHas('favorites',[
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+        ]);
+    }
+
+    public function test_user_can_remove_favorite()
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+        $product = Product::factory()->create([
+        'category_id' => $category->id,
+        ]);
+
+        $user->favoriteProducts()->syncWithoutDetaching([$product->id]);
+
+        $res = $this->actingAs($user,'sanctum')->deleteJson("/favorites/{$product->id}");
+        $res->assertOk()->assertJson([
+            'message' => 'お気に入りから削除しました。',
+        ]);
+        $this->assertDatabaseMissing('favorites',[
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## ■ 実装内容（バックエンド）
- `FavoriteController` を新規実装  
  - **GET /favorites**  
    - ログインユーザーのお気に入り商品一覧を取得  
  - **POST /favorites**  
    - 指定商品のお気に入り追加
  - **DELETE /favorites/{productId}**  
    - 指定商品のお気に入り解除  

---

## ■ 実装内容（フロントエンド）
- **商品一覧ページ (`ProductList`)**  
  - ハートボタンを実装し、お気に入り登録／解除のトグル
  - 未ログイン時は API が `401` を返すため、アラートで通知  

- **お気に入り一覧ページ (`FavoriteList`) を新規作成**  
  - `/favorites` にてお気に入り商品を一覧表示  
  - ヘッダーのハートアイコンから遷移可能  

---

## ■ テスト用コマンド（バックエンド：FavoriteController）
```
docker compose exec app php artisan test --filter=FavoriteControllerTest
```