### PR TITLE
apiのプレフィックス追加してtest修正

### DIFF
--- a/server/laravel/tests/Feature/Admin/CategoryControllerTest.php
+++ b/server/laravel/tests/Feature/Admin/CategoryControllerTest.php
@@ -24,7 +24,7 @@ class CategoryControllerTest extends TestCase{
     public function test_category_index()
     {
         Category::factory()->count(2)->create();
-        $response = $this->get('/admin/categories');
+        $response = $this->adminGet('categories');
         $response->assertOk()->assertJsonCount(2);
     }
 
@@ -34,7 +34,7 @@ class CategoryControllerTest extends TestCase{
             'name' => '新規カテゴリ',
         ];
 
-        $response = $this->postJson('/admin/categories', $postData);
+        $response = $this->adminPost('categories', $postData);
         $response-> assertCreated()->assertJsonFragment(['name' => '新規カテゴリ']);
         $this->assertDatabaseHas('categories', ['name' => '新規カテゴリ',]);
     }
@@ -45,14 +45,14 @@ class CategoryControllerTest extends TestCase{
             // 'name' => 'カテゴリ名がない場合',
         ];
 
-        $response = $this->postJson('/admin/categories', $postDataWithoutName);
+        $response = $this->adminPost('categories', $postDataWithoutName);
         $response->assertStatus(422);
         $this->assertDatabaseMissing('categories', ['name' => null]);
     }
 
     public function test_category_show(){
         $category = Category::factory()->create();
-        $response = $this->get("/admin/categories/{$category->id}");
+        $response = $this->adminGet("categories/{$category->id}");
         $response->assertOk()->assertJsonFragment(['id' => $category->id,]);
     }
 
@@ -63,7 +63,7 @@ class CategoryControllerTest extends TestCase{
             'name' => '更新後カテゴリ名',
         ];
 
-        $response = $this->putJson("/admin/categories/{$category->id}", $updateData);
+        $response = $this->adminPut("categories/{$category->id}", $updateData);
         $response->assertOk()->assertJsonFragment(['name' => '更新後カテゴリ名',]);
         $this->assertDatabaseHas('categories', ['id' => $category->id, 'name' => '更新後カテゴリ名',]);
     }
@@ -75,7 +75,7 @@ class CategoryControllerTest extends TestCase{
             'name' => null, // 無効なデータ（空の名前）
         ];
 
-        $response = $this->putJson("/admin/categories/{$category->id}", $updateData);
+        $response = $this->adminPut("categories/{$category->id}", $updateData);
         $response->assertStatus(422);
         $this->assertDatabaseHas('categories', ['id' => $category->id, 'name' => '更新前カテゴリ名',]);
     }
@@ -83,7 +83,7 @@ class CategoryControllerTest extends TestCase{
     public function test_category_delete(){
         $category = Category::factory()->create();
 
-        $response = $this->deleteJson("/admin/categories/{$category->id}");
+        $response = $this->adminDelete("categories/{$category->id}");
         $response->assertOk();
         $this->assertDatabaseMissing('categories', ['id' => $category->id,]);
     }
@@ -97,17 +97,17 @@ class CategoryControllerTest extends TestCase{
         $postData = [
             'name' => 'ガードテストカテゴリ',
         ];
-        $createResponse = $this->postJson('/admin/categories', $postData);
+        $createResponse = $this->adminPost('categories', $postData);
         $createResponse->assertForbidden();
 
         $category = Category::factory()->create(['name' => '既存カテゴリ']);
         $updateData = [
             'name' => '更新後カテゴリ名',
         ];
-        $updateResponse = $this->putJson("/admin/categories/{$category->id}", $updateData);
+        $updateResponse = $this->adminPut("categories/{$category->id}", $updateData);
         $updateResponse->assertForbidden();
 
-        $deleteResponse = $this->deleteJson("/admin/categories/{$category->id}");
+        $deleteResponse = $this->adminDelete("categories/{$category->id}");
         $deleteResponse->assertForbidden();
     }
 

--- a/server/laravel/tests/Feature/Admin/ProductControllerTest.php
+++ b/server/laravel/tests/Feature/Admin/ProductControllerTest.php
@@ -28,7 +28,7 @@ class ProductControllerTest extends TestCase
     {
 
         Product::factory()->count(2)->create(['category_id' => 1]);
-        $response = $this->get('/admin/products');
+        $response = $this->adminGet('products');
         $response->assertOk()->assertJsonCount(2);
     }
 
@@ -50,7 +50,7 @@ class ProductControllerTest extends TestCase
             'released_at' => now()->toDateTimeString(),
         ];
 
-        $response = $this->postJson('/admin/products', $postData);
+        $response = $this->adminPost('products', $postData);
         $response->assertCreated()->assertJsonFragment(['title' => '新規商品']);
         $this->assertDatabaseHas('products', ['title' => '新規商品']);
     }
@@ -72,14 +72,14 @@ class ProductControllerTest extends TestCase
             'released_at' => now()->toDateTimeString(),
         ];
 
-        $response = $this->postJson('/admin/products', $postDataWithoutTitle);
+        $response = $this->adminPost('products', $postDataWithoutTitle);
         $response->assertStatus(422);
     }
 
     public function test_product_show()
     {
         $product = Product::factory()->create(['category_id' => 1]);
-        $response = $this->get("/admin/products/{$product->id}");
+        $response = $this->adminGet("products/{$product->id}");
         $response->assertOk()->assertJsonFragment(['id' => $product->id]);
     }
 
@@ -88,7 +88,7 @@ class ProductControllerTest extends TestCase
         $product = Product::factory()->create(['category_id' => 1, 'title'=>'旧タイトル']);
         $updatedData = $product->toArray();
         $updatedData['title'] = '新タイトル';
-        $response = $this->putJson("/admin/products/{$product->id}", $updatedData);
+        $response = $this->adminPut("products/{$product->id}", $updatedData);
         $response->assertOk()->assertJsonFragment(['title' => '新タイトル']);
         $this->assertDatabaseHas('products', ['id' => $product->id, 'title' => '新タイトル']);
     }
@@ -98,7 +98,7 @@ class ProductControllerTest extends TestCase
         $product = Product::factory()->create(['category_id' => 1, 'title'=>'旧タイトル']);
         $updatedData = $product->toArray();
         $updatedData['title'] = null;
-        $response = $this->putJson("/admin/products/{$product->id}", $updatedData);
+        $response = $this->adminPut("products/{$product->id}", $updatedData);
         $response->assertStatus(422);
         $this->assertDatabaseHas('products', ['id' => $product->id, 'title' => '旧タイトル']);
     }
@@ -106,7 +106,7 @@ class ProductControllerTest extends TestCase
     public function test_product_delete()
     {
         $product = Product::factory()->create(['category_id' => 1]);
-        $response = $this->delete("/admin/products/{$product->id}");
+        $response = $this->adminDelete("products/{$product->id}");
         $response->assertOk();
         $this->assertDatabaseMissing('products', ['id' => $product->id]);
     }
@@ -134,12 +134,12 @@ class ProductControllerTest extends TestCase
             'released_at' => now()->toDateTimeString(),
         ];
 
-        $createResponse = $this->postJson('/admin/products', $postData);
+        $createResponse = $this->adminPost('products', $postData);
         $createResponse->assertForbidden();
 
         // 削除もガードされる
         $product = Product::factory()->create(['category_id' => 1]);
-        $deleteResponse = $this->delete("/admin/products/{$product->id}");
+        $deleteResponse = $this->adminDelete("products/{$product->id}");
         $deleteResponse->assertForbidden();
     }
 }

--- a/server/laravel/tests/Feature/AuthTest.php
+++ b/server/laravel/tests/Feature/AuthTest.php
@@ -27,7 +27,7 @@ class AuthTest extends TestCase
         ]);
 
         
-        $response = $this->postJson('/login', [
+        $response = $this->apiPost('login', [
             'email' => 'test@example.com',
             'password' => 'password123',
         ]);
@@ -48,7 +48,7 @@ class AuthTest extends TestCase
             'password' => Hash::make('password123'),
         ]);
 
-        $response = $this->withSession([])->postJson('/login', [
+        $response = $this->withSession([])->apiPost('login', [
             'email' => 'test@example.com',
             'password' => 'wrongpassword',
         ]);
@@ -71,7 +71,7 @@ class AuthTest extends TestCase
             'password_confirmation' => 'password123',
         ];
 
-        $response = $this->withSession([])->postJson('/register', $userData);
+        $response = $this->withSession([])->apiPost('register', $userData);
 
         $response->assertStatus(201)
                 ->assertJson([
@@ -106,7 +106,7 @@ class AuthTest extends TestCase
             'password_confirmation' => '456',
         ];
 
-        $response = $this->withSession([])->postJson('/register', $invalidData);
+        $response = $this->withSession([])->apiPost('register', $invalidData);
 
         $response->assertStatus(422)
                 ->assertJsonValidationErrors(['name', 'email', 'password']);
@@ -128,7 +128,7 @@ class AuthTest extends TestCase
             'password_confirmation' => 'password123',
         ];
 
-        $response = $this->postJson('/register', $userData);
+        $response = $this->apiPost('register', $userData);
 
         $response->assertStatus(422)
                 ->assertJsonValidationErrors(['email']);
@@ -142,7 +142,7 @@ class AuthTest extends TestCase
         $user = User::factory()->create();
 
         // ログイン
-        $loginResponse = $this->postJson('/login', [
+        $loginResponse = $this->apiPost('login', [
             'email' => $user->email,
             'password' => 'password',
         ]);
@@ -150,7 +150,7 @@ class AuthTest extends TestCase
         $loginResponse->assertStatus(200);
 
         // ログアウト
-        $logoutResponse = $this->postJson('/logout');
+        $logoutResponse = $this->apiPost('logout');
 
         $logoutResponse->assertStatus(200)
                       ->assertJson([
@@ -163,7 +163,7 @@ class AuthTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_logout()
     {
-        $response = $this->postJson('/logout');
+        $response = $this->apiPost('logout');
 
         $response->assertStatus(401);
     }
@@ -180,7 +180,7 @@ class AuthTest extends TestCase
             'password_confirmation' => 'differentpassword',
         ];
 
-        $response = $this->postJson('/register', $userData);
+        $response = $this->apiPost('register', $userData);
 
         $response->assertStatus(422)
                 ->assertJsonValidationErrors(['password']);
@@ -198,7 +198,7 @@ class AuthTest extends TestCase
             'password_confirmation' => '123',
         ];
 
-        $response = $this->postJson('/register', $userData);
+        $response = $this->apiPost('register', $userData);
 
         $response->assertStatus(422)
                 ->assertJsonValidationErrors(['password']);
@@ -216,14 +216,14 @@ class AuthTest extends TestCase
             'password_confirmation' => 'password123',
         ];
 
-        $response = $this->postJson('/register', $userData);
+        $response = $this->apiPost('register', $userData);
 
         $response->assertStatus(201);
 
         // 登録後、ユーザー情報を取得できることを確認
         $user = User::where('email', 'john@example.com')->first();
         $this->actingAs($user, 'web'); // actingAsで認証済みを仮定
-        $userResponse = $this->getJson('/user');
+        $userResponse = $this->apiGet('user');
         
         $userResponse->assertStatus(200)
                     ->assertJson([
@@ -247,7 +247,7 @@ class AuthTest extends TestCase
         ];
 
         // ユーザー登録APIを呼び出す
-        $response = $this->postJson('/register', $userData);
+        $response = $this->apiPost('register', $userData);
 
         $response->assertStatus(201);
 

--- a/server/laravel/tests/Feature/CartControllerTest.php
+++ b/server/laravel/tests/Feature/CartControllerTest.php
@@ -36,7 +36,7 @@ class CartControllerTest extends TestCase
     {
         [$product, $price] = $this->createProductAndPrice();
 
-        $response = $this->postJson('/cart', [
+        $response = $this->apiPost('cart', [
             'product_id' => $product->id,
             'price_id' => $price->id,
             'quantity' => 2,
@@ -61,7 +61,7 @@ class CartControllerTest extends TestCase
     {
         [$product, $price] = $this->createProductAndPrice();
 
-        $createResponse = $this->postJson('/cart', [
+        $createResponse = $this->apiPost('cart', [
             'product_id' => $product->id,
             'price_id' => $price->id,
             'quantity' => 1,
@@ -71,7 +71,7 @@ class CartControllerTest extends TestCase
 
         $itemId = $createResponse->json('items.0.id');
         
-        $updateResponse = $this->withCookie('cart_token', $token)->withCredentials()->putJson('/cart', [
+        $updateResponse = $this->withCookie('cart_token', $token)->withCredentials()->apiPut('cart', [
             'cart_item_id' => $itemId,
             'quantity' => 4,
         ]);
@@ -82,7 +82,7 @@ class CartControllerTest extends TestCase
                 'quantity' => 4,
             ]);
 
-        $deleteResponse = $this->withCookie('cart_token', $token)->withCredentials()->deleteJson('/cart', [
+        $deleteResponse = $this->withCookie('cart_token', $token)->withCredentials()->apiDelete('cart', [
             'cart_item_id' => $itemId,
         ]);
 
@@ -98,7 +98,7 @@ class CartControllerTest extends TestCase
     {
         [$guestProduct, $guestPrice] = $this->createProductAndPrice();
 
-        $guestResponse = $this->postJson('/cart', [
+        $guestResponse = $this->apiPost('cart', [
             'product_id' => $guestProduct->id,
             'price_id' => $guestPrice->id,
             'quantity' => 2,
@@ -121,7 +121,7 @@ class CartControllerTest extends TestCase
 
         $response = $this->withCookie('cart_token', $guestToken)->withCredentials()
             ->actingAs($user)
-            ->getJson('/cart');
+            ->apiGet('cart');
 
         $response->assertStatus(200)
             ->assertJsonFragment(['user_id' => $user->id])

--- a/server/laravel/tests/Feature/CategoryControllerTest.php
+++ b/server/laravel/tests/Feature/CategoryControllerTest.php
@@ -13,14 +13,14 @@ class CategoryControllerTest extends TestCase
     public function test_category_index()
     {
         Category::factory()->count(2)->create();
-        $response = $this->get('/categories');
+        $response = $this->apiGet('categories');
         $response->assertOk()->assertJsonCount(2);
     }
 
     public function test_category_show()
     {
         $category = Category::factory()->create();
-        $response = $this->get("/categories/{$category->id}");
+        $response = $this->apiGet("categories/{$category->id}");
         $response->assertOk()->assertJsonFragment(['id' => $category->id,]);
     }
 }

--- a/server/laravel/tests/Feature/ExampleTest.php
+++ b/server/laravel/tests/Feature/ExampleTest.php
@@ -12,7 +12,7 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        $response = $this->get('/');
+        $response = $this->apiGet('/');
 
         $response->assertStatus(200);
     }

--- a/server/laravel/tests/Feature/FavoriteControllerTest.php
+++ b/server/laravel/tests/Feature/FavoriteControllerTest.php
@@ -19,9 +19,9 @@ class FavoriteControllerTest extends TestCase
      */
     public function test_guest_cannnot_access_favorites()
     {
-        $this->getJson('/favorites')->assertUnauthorized();
-        $this->postJson('/favorites',['product_id' => 1])->assertUnauthorized();
-        $this->deleteJson('/favorites/1')->assertUnauthorized();
+        $this->apiGet('favorites')->assertUnauthorized();
+        $this->apiPost('favorites', ['product_id' => 1])->assertUnauthorized();
+        $this->apiDelete('favorites/1')->assertUnauthorized();
     }
 
     public function test_user_can_get_own_favorites()
@@ -42,7 +42,7 @@ class FavoriteControllerTest extends TestCase
         $userA->favoriteProducts()->syncWithoutDetaching([$productA->id]);
         $userB->favoriteProducts()->syncWithoutDetaching([$productB->id]);
 
-        $res = $this->actingAs($userA,'sanctum')->getJson('/favorites');
+        $res = $this->actingAs($userA, 'sanctum')->apiGet('favorites');
         $res->assertOk()->assertJsonFragment([
             'id' => $productA->id,
         ])->assertJsonMissing([
@@ -58,7 +58,7 @@ class FavoriteControllerTest extends TestCase
         'category_id' => $category->id,
         ]);
 
-        $res = $this->actingAs($user,'sanctum')->postJson('/favorites',[
+        $res = $this->actingAs($user, 'sanctum')->apiPost('favorites', [
             'product_id' => $product->id,
         ]);
 
@@ -82,7 +82,7 @@ class FavoriteControllerTest extends TestCase
 
         $user->favoriteProducts()->syncWithoutDetaching([$product->id]);
 
-        $res = $this->actingAs($user,'sanctum')->deleteJson("/favorites/{$product->id}");
+        $res = $this->actingAs($user, 'sanctum')->apiDelete("favorites/{$product->id}");
         $res->assertOk()->assertJson([
             'message' => 'お気に入りから削除しました。',
         ]);

--- a/server/laravel/tests/Feature/PublicProductControllerTest.php
+++ b/server/laravel/tests/Feature/PublicProductControllerTest.php
@@ -24,7 +24,7 @@ class PublicProductControllerTest extends TestCase
             'status' => 'draft',
         ]);
 
-        $response = $this->get('/products');
+        $response = $this->apiGet('products');
         $response->assertOk();
         $response->assertJsonFragment(['id' => $published->id]);
         $response->assertJsonMissing(['id' => $draft->id]);
@@ -42,10 +42,10 @@ class PublicProductControllerTest extends TestCase
             'category_id' => $category->id,
             'status' => 'draft',
         ]);
-        $responsePublished = $this->get("/products/{$published->id}");
+        $responsePublished = $this->apiGet("products/{$published->id}");
         $responsePublished->assertOk();
         $responsePublished->assertJsonFragment(['id' => $published->id]);
-        $responseDraft = $this->get("/products/{$draft->id}");
+        $responseDraft = $this->apiGet("products/{$draft->id}");
         $responseDraft->assertStatus(404);
     }
 
@@ -76,7 +76,7 @@ class PublicProductControllerTest extends TestCase
             'title' => 'Alpha Draft',
         ]);
 
-        $response = $this->getJson('/products/search?keyword=alpha');
+        $response = $this->apiGet('products/search?keyword=alpha');
 
         $response->assertOk();
         $response->assertJsonPath('count', 2);
@@ -90,7 +90,7 @@ class PublicProductControllerTest extends TestCase
 
     public function test_product_search_requires_keyword()
     {
-        $response = $this->getJson('/products/search');
+        $response = $this->apiGet('products/search');
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['keyword']);

--- a/server/laravel/tests/Feature/WishlistControllerTest.php
+++ b/server/laravel/tests/Feature/WishlistControllerTest.php
@@ -32,7 +32,7 @@ class WishlistControllerTest extends TestCase
         $product = $this->createProduct();
 
         $response = $this->actingAs($user)
-            ->postJson('/wishlist',[
+            ->apiPost('wishlist',[
             'product_id' => $product->id,
             'name' => 'test_name',
             ]);
@@ -62,7 +62,7 @@ class WishlistControllerTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)
-            ->deleteJson('/wishlist',[
+            ->apiDelete('wishlist',[
                 'product_id' => $product->id,
         ]);
 
@@ -92,7 +92,7 @@ class WishlistControllerTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)
-            ->postJson('/wishlist', [
+            ->apiPost('wishlist', [
                 'product_id' => $product->id,
             ]);
 

--- a/server/laravel/tests/TestCase.php
+++ b/server/laravel/tests/TestCase.php
@@ -6,5 +6,61 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected string $apiPrefix = '/api';
+
+    protected function api(string $path): string
+    {
+        return $this->apiPrefix . '/' . ltrim($path, '/');
+    }
+
+    protected function apiGet(string $path, array $headers = [])
+    {
+        return $this->getJson($this->api($path), $headers);
+    }
+
+    protected function apiPost(string $path, array $data = [], array $headers = [])
+    {
+        return $this->postJson($this->api($path), $data, $headers);
+    }
+
+    protected function apiPut(string $path, array $data = [], array $headers = [])
+    {
+        return $this->putJson($this->api($path), $data, $headers);
+    }
+
+    protected function apiDelete(string $path, array $data = [], array $headers = [])
+    {
+        return $this->deleteJson($this->api($path), $data, $headers);
+    }
+
+    // =========================
+    // Admin (web) path helpers
+    // =========================
+
+    protected string $adminPrefix = '/api/admin';
+
+    protected function admin(string $path): string
+    {
+        return $this->adminPrefix . '/' . ltrim($path, '/');
+    }
+
+    protected function adminGet(string $path, array $headers = [])
+    {
+        return $this->getJson($this->admin($path), $headers);
+    }
+
+    protected function adminPost(string $path, array $data = [], array $headers = [])
+    {
+        return $this->postJson($this->admin($path), $data, $headers);
+    }
+
+    protected function adminPut(string $path, array $data = [], array $headers = [])
+    {
+        return $this->putJson($this->admin($path), $data, $headers);
+    }
+
+    protected function adminDelete(string $path, array $data = [], array $headers = [])
+    {
+        return $this->deleteJson($this->admin($path), $data, $headers);
+    }
 }


### PR DESCRIPTION
stg作成の際に、フロントとバックエンドを区別するためにバックエンド側のrouteにapiのプレフィックスをつけた修正の対応。

・abstractのTestCase.phpにメソッド書いて、それを書くテストコードで継承して使用できるようにして/apiのプレフィックス追加しました。