### PR TITLE
Feature/order history front

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000/api

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import AdminCategoryCreate from '@/pages/admin/AdminCategoryCreate';
 import AdminCategoryEdit from '@/pages/admin/AdminCategoryEdit';
 import FavoriteList from './pages/FavoriteList';
 import Cart from './pages/Cart';
+import OrderHistory from './pages/OrderHistory';
 
 function App() {
   return (
@@ -29,7 +30,8 @@ function App() {
           <Route path="/cart" element={<Cart />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
-          <Route path="/product-list" element={<ProductList/>} />
+          <Route path="/product-list" element={<ProductList />} />
+          <Route path="/orderHistory" element={<OrderHistory />} />
         </Route>
         <Route path="admin" element={<AdminLayout />}>
           <Route path="products" element={<AdminProductList />} />

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -39,6 +39,10 @@ function Header() {
     navigate('/login');
   };
 
+  const handleOrderhistory = async () => {
+    navigate('/orderHistory');
+  };
+
   const handleFavoriteClick = () => {
     navigate('/favorites');
   };
@@ -105,7 +109,12 @@ function Header() {
                 </Button>
               </NavigationMenuItem>
               <NavigationMenuItem>
-                <Button size="icon-sm" aria-label="Submit" variant="ghost">
+                <Button
+                  size="icon-sm"
+                  aria-label="Submit"
+                  variant="ghost"
+                  onClick={handleOrderhistory}
+                >
                   <History />
                 </Button>
               </NavigationMenuItem>

--- a/client/src/pages/OrderHistory.tsx
+++ b/client/src/pages/OrderHistory.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Heading from '@/components/Heading';
+import { Package, ReceiptText } from 'lucide-react';
+import { listOrderHistory } from '@/services/orderHistoryService';
+import type { Order } from '@/types/OrderType';
+import type { OrderItem } from '@/types/OrderItemType';
+
+const formatYmdHm = (iso?: string | null) => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${y}/${m}/${day} ${hh}:${mm}`;
+};
+
+const yen = (v: number) => {
+  try {
+    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(v);
+  } catch {
+    return `${v}円`;
+  }
+};
+
+const OrderItemRow = ({ item }: { item: OrderItem }) => {
+  const product = item.product;
+  const productId = product?.id;
+
+  return (
+    <Link
+      to={`/products/${productId}`}
+      className="flex gap-3 p-3 rounded-md hover:bg-gray-50 transition"
+    >
+      <img
+        src={(product as any)?.imageUrl || 'https://via.placeholder.com/150'}
+        alt={(product as any)?.title}
+        className="w-16 h-16 object-cover rounded-md border"
+      />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-gray-800 truncate">
+              {(product as any)?.title}
+            </p>
+            {(product as any)?.description ? (
+              <p className="text-xs text-gray-600 mt-1 line-clamp-2">
+                {(product as any).description}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="text-right shrink-0">
+            <p className="text-xs text-gray-600">数量</p>
+            <p className="text-sm font-semibold text-gray-800">{item.quantity}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between mt-2">
+          <p className="text-xs text-gray-600">
+            単価: {item.unit_amount != null ? yen(item.unit_amount) : '—'}
+          </p>
+          <p className="text-xs text-gray-600">
+            小計: {item.unit_amount != null ? yen(item.unit_amount * item.quantity) : '—'}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+const OrderCard = ({ order }: { order: Order }) => {
+  const items = order.order_items ?? [];
+  const total =
+    (order as any).total_amount != null
+      ? (order as any).total_amount
+      : items.reduce((sum, it) => {
+          const qty = it.quantity;
+          const unit = it.unit_amount == null ? 0 : it.unit_amount;
+          return sum + qty * unit;
+        }, 0);
+
+  return (
+    <div className="bg-white border rounded-lg shadow-sm overflow-hidden">
+      <div className="p-4 border-b bg-gray-50">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-gray-800 truncate">注文 #{order.id}</p>
+            <p className="text-xs text-gray-600 mt-1">
+              注文日時: {formatYmdHm(order.created_at || order.updated_at)}
+            </p>
+          </div>
+
+          <div className="text-right shrink-0">
+            <p className="text-xs text-gray-600">ステータス</p>
+            <p className="text-sm font-semibold text-gray-800">{order.status || '—'}</p>
+          </div>
+
+          <div className="text-right shrink-0">
+            <p className="text-xs text-gray-600">合計</p>
+            <p className="text-sm font-semibold text-gray-800">{yen(total)}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="divide-y">
+        {items.length === 0 ? (
+          <div className="p-6 text-center text-gray-600 text-sm">注文商品の情報がありません。</div>
+        ) : (
+          items.map((it) => (
+            <OrderItemRow key={it.id ?? `${order.id}-${it.product_id}`} item={it} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+const OrderHistoryPage = () => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const run = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await listOrderHistory();
+        if (!mounted) return;
+        setOrders(Array.isArray(data) ? data : []);
+      } catch (e: any) {
+        if (!mounted) return;
+        if (e?.status === 401) {
+          setError('ログインが必要です。');
+        } else {
+          setError('購入履歴の取得に失敗しました。');
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (loading) {
+    return <div className="p-10 text-center">読み込み中...</div>;
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 py-10">
+        <div className="flex items-center gap-2">
+          <Heading>購入履歴</Heading>
+        </div>
+
+        <p className="text-sm text-gray-600 mt-2">過去の注文一覧です。</p>
+
+        <div className="mt-6 bg-white border rounded-lg shadow-sm p-6">
+          {error ? (
+            <div className="text-center text-red-600 py-10">{error}</div>
+          ) : orders.length === 0 ? (
+            <div className="text-center text-gray-600 py-10">購入履歴はありません。</div>
+          ) : (
+            <div className="space-y-6">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm text-gray-700">
+                  <ReceiptText className="h-4 w-4" />
+                  <span>注文件数: {orders.length}</span>
+                </div>
+
+                <div className="flex items-center gap-2 text-sm text-gray-700">
+                  <Package className="h-4 w-4" />
+                  <span>詳細は商品をクリック</span>
+                </div>
+              </div>
+
+              {orders.map((o) => (
+                <OrderCard key={o.id} order={o} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrderHistoryPage;

--- a/client/src/services/orderHistoryService.ts
+++ b/client/src/services/orderHistoryService.ts
@@ -1,0 +1,22 @@
+import type { Order } from '@/types/OrderType';
+import { API_URL } from '@/config/api';
+
+function makeError(status: number, message?: string) {
+  const err: Error & { status?: number } = new Error(message || `HTTP ${status}`);
+  err.status = status;
+  return err;
+}
+
+export const listOrderHistory = async (): Promise<Order[]> => {
+  const res = await fetch(`${API_URL}/order_history`, {
+    method: 'GET',
+    headers: { Accept: `application/json` },
+    credentials: 'include',
+  });
+
+  if (res.status === 401) throw makeError(401, 'Unauthorized');
+  if (!res.ok) throw makeError(res.status);
+
+  const data = await res.json();
+  return Array.isArray(data) ? data : data.data || [];
+};

--- a/client/src/types/OrderItemType.ts
+++ b/client/src/types/OrderItemType.ts
@@ -1,0 +1,9 @@
+import type { Product } from './ProductType';
+
+export interface OrderItem {
+  id: number;
+  product_id: number;
+  quantity: number;
+  unit_amount?: number | null;
+  product?: Product | null;
+}

--- a/client/src/types/OrderType.ts
+++ b/client/src/types/OrderType.ts
@@ -1,0 +1,10 @@
+import type { OrderItem } from './OrderItemType';
+
+export interface Order {
+  id: number;
+  user_id: number;
+  status?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  order_items?: OrderItem[];
+}

--- a/server/laravel/app/Http/Controllers/OrderHistoryController.php
+++ b/server/laravel/app/Http/Controllers/OrderHistoryController.php
@@ -9,19 +9,13 @@ class OrderHistoryController extends Controller
 {
     public function index(Request $request)
     {
-        $userId = $request->input('user_id');
+        $user = $request->user();
+        if (!$user) return response()->json(['message' => 'Unauthorized'], 401);
 
-        if(!$userId){
-            return response()->json(['message' => 'User ID is required'], 400);
-        }
+        $orders = Order::where('user_id', $user->id)
+        ->with(['orderItems.product'])
+        ->get();
 
-        $orders = Order::where('user_id', $userId)
-            ->with(['orderItems.product'])
-            ->get();
-
-        return response()->json([
-            'status' => 'success',
-            'data' =>$orders
-        ]);
+        return response()->json(['status' => 'success', 'data' => $orders]);
     }
 }

--- a/server/laravel/database/seeders/OrderItemSeeder.php
+++ b/server/laravel/database/seeders/OrderItemSeeder.php
@@ -13,5 +13,54 @@ class OrderItemSeeder extends Seeder
      */
     public function run(): void
     {
+        $now = now();
+
+        DB::table('order_items')->insert([
+            // order_id = 1
+            [
+                'order_id' => 1,
+                'product_id' => 1,
+                'price_id' => 1,
+                'quantity' => 2,
+                'unit_amount' => 1200,
+                'created_at' => $now,
+            ],
+            [
+                'order_id' => 1,
+                'product_id' => 2,
+                'price_id' => 2,
+                'quantity' => 1,
+                'unit_amount' => 2400,
+                'created_at' => $now,
+            ],
+
+            // order_id = 2
+            [
+                'order_id' => 2,
+                'product_id' => 1,
+                'price_id' => 1,
+                'quantity' => 1,
+                'unit_amount' => 1200,
+                'created_at' => $now->copy()->subDays(3),
+            ],
+            [
+                'order_id' => 2,
+                'product_id' => 3,
+                'price_id' => 3,
+                'quantity' => 2,
+                'unit_amount' => 1000,
+                'created_at' => $now->copy()->subDays(3),
+            ],
+
+            // order_id = 3
+            [
+                'order_id' => 3,
+                'product_id' => 4,
+                'price_id' => 4,
+                'quantity' => 1,
+                'unit_amount' => 1500,
+                'created_at' => $now->copy()->subDays(7),
+            ],
+        ]);
     }
 }

--- a/server/laravel/database/seeders/OrderSeeder.php
+++ b/server/laravel/database/seeders/OrderSeeder.php
@@ -13,5 +13,42 @@ class OrderSeeder extends Seeder
      */
     public function run(): void
     {
+        // users テーブルに存在する前提で user_id を使用
+        $now = now();
+
+        DB::table('orders')->insert([
+            [
+                'user_id' => 1,
+                'status' => 'completed',
+                'total_amount' => 4800,
+                'email' => 'test@email.com',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'user_id' => 1,
+                'status' => 'processing',
+                'total_amount' => 3200,
+                'email' => 'test@email.com',
+                'created_at' => $now->copy()->subDays(3),
+                'updated_at' => $now->copy()->subDays(3),
+            ],
+            [
+                'user_id' => 2,
+                'status' => 'pending',
+                'total_amount' => 1500,
+                'email' => 'admin@example.com',
+                'created_at' => $now->copy()->subDays(7),
+                'updated_at' => $now->copy()->subDays(7),
+            ],
+            [
+                'user_id' => 2,
+                'status' => 'cancelled',
+                'total_amount' => 0,
+                'email' => 'admin@example.com',
+                'created_at' => $now->copy()->subDays(10),
+                'updated_at' => $now->copy()->subDays(10),
+            ],
+        ]);
     }
 }

--- a/server/laravel/tests/Feature/OrderHistoryControllerTest.php
+++ b/server/laravel/tests/Feature/OrderHistoryControllerTest.php
@@ -39,7 +39,7 @@ class OrderHistoryControllerTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)
-                         ->getJson("/api/order_history?user_id={$user->id}");
+                         ->getJson("/api/order_history");
 
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -63,12 +63,10 @@ class OrderHistoryControllerTest extends TestCase
             ->assertJsonPath('data.0.order_items.0.product.title', 'test_product');
     }
 
-    public function test_returns_error_if_user_id_is_missing()
+    public function test_returns_401_if_unauthenticated(): void
     {
-        $user = User::factory()->create();
-        $response = $this->actingAs($user)->getJson('/api/order_history');
-
-        $response->assertStatus(400);
+        $response = $this->getJson('/api/order_history');
+        $response->assertStatus(401);
     }
 }
 


### PR DESCRIPTION
## 概要
- 購入履歴のフロントを作成
- 購入履歴（OrderHistory）取得処理において、  
**フロントで userId をパラメータとして渡す前提でしたが、フロントエンドから userId を取得できなかったため
バックエンド側で認証ユーザー（`auth()->user()`）を取得する方式に変更**しました。



## 対応内容
### フロントエンド
- 認証瑞のユーザーの購入履歴を表示しました。
### バックエンド
- 認証済みユーザーを `auth()->user()` から取得
- 購入履歴は **認証ユーザー本人のデータのみ** を返却
- 購入履歴のSeederを追加して確認
